### PR TITLE
Rewrite MyModule using ConnBuilder

### DIFF
--- a/examples/MyModule/CMakeLists.txt
+++ b/examples/MyModule/CMakeLists.txt
@@ -33,14 +33,18 @@ cmake_minimum_required( VERSION 2.8.12 )
 
 # 1) Name your module here, i.e. add later with -Dexternal-modules=my:
 set( SHORT_NAME my )
+
 #    the complete module name is here:
 set( MODULE_NAME ${SHORT_NAME}module )
+
 # 2) Add all your sources here
 set( MODULE_SOURCES
     mymodule.h mymodule.cpp
     pif_psc_alpha.cpp pif_psc_alpha.h
     drop_odd_spike_connection.h
+    step_pattern_builder.h step_pattern_builder.cpp
     )
+
 # 3) We require a header name like this:
 set( MODULE_HEADER ${MODULE_NAME}.h )
 # containing the class description of the class extending the SLIModule
@@ -81,6 +85,7 @@ execute_process(
     OUTPUT_VARIABLE NEST_COMPILER
     OUTPUT_STRIP_TRAILING_WHITESPACE
 )
+
 # One check on first execution, if `nest-config` is working.
 if ( NOT RES_VAR EQUAL 0 )
   message( FATAL_ERROR "Cannot run `${NEST_CONFIG}`. Please specify correct `nest-config` via -Dwith-nest=... " )

--- a/examples/MyModule/mymodule.cpp
+++ b/examples/MyModule/mymodule.cpp
@@ -31,6 +31,7 @@
 #include "step_pattern_builder.h"
 
 // Includes from nestkernel:
+#include "connection_manager_impl.h"
 #include "connector_model_impl.h"
 #include "dynamicloader.h"
 #include "exceptions.h"
@@ -128,8 +129,7 @@ mynest::MyModule::init( SLIInterpreter* i )
         TargetIdentifierPtrRport > >( "drop_odd_synapse" );
 
   // Register connection rule.
-  nest::kernel()
-    .connection_manager.register_conn_builder< StepPatternBuilder >(
+  nest::kernel().connection_manager.register_conn_builder< StepPatternBuilder >(
     "step_pattern" );
 
 } // MyModule::init()

--- a/examples/MyModule/mymodule.cpp
+++ b/examples/MyModule/mymodule.cpp
@@ -28,6 +28,7 @@
 // include headers with your own stuff
 #include "drop_odd_spike_connection.h"
 #include "pif_psc_alpha.h"
+#include "step_pattern_builder.h"
 
 // Includes from nestkernel:
 #include "connector_model_impl.h"
@@ -100,113 +101,6 @@ mynest::MyModule::commandstring( void ) const
   return std::string( "(mymodule-init) run" );
 }
 
-/* BeginDocumentation
-   Name: StepPatternConnect - Connect sources and targets with a stepping
-                              pattern
-
-   Synopsis:
-   [sources] source_step [targets] target_step synmod StepPatternConnect ->
-                                                                   n_connections
-
-   Parameters:
-   [sources]     - Array containing GIDs of potential source neurons
-   source_step   - Make connection from every source_step'th neuron
-   [targets]     - Array containing GIDs of potential target neurons
-   target_step   - Make connection to every target_step'th neuron
-   synmod        - The synapse model to use (literal, must be key in
-   synapsedict)
-   n_connections - Number of connections made
-
-   Description:
-   This function subsamples the source and target arrays given with steps
-   source_step and target_step, beginning with the first element in each array,
-   and connects the selected nodes.
-
-   Example:
-   /first_src 0 /network_size get def
-   /last_src /iaf_neuron 20 Create def  % nodes  1 .. 20
-   /src [first_src last_src] Range def
-   /last_tgt /iaf_neuron 10 Create def  % nodes 21 .. 30
-   /tgt [last_src 1 add last_tgt] Range def
-
-   src 6 tgt 4 /drop_odd_spike StepPatternConnect
-
-   This connects nodes [1, 7, 13, 19] as sources to nodes [21, 25,
-   29] as targets using synapses of type drop_odd_spike, and
-   returning 12 as the number of connections.  The following
-   command will print the connections (you must paste the SLI
-   command as one long line):
-
-   src { /s Set << /source s >> GetConnections { cva 1 get } Map dup length 0 gt
-   { cout s <- ( -> )
-   <- exch <-- endl } if ; } forall
-   1 -> [21 25 29]
-   7 -> [21 25 29]
-   13 -> [21 25 29]
-   19 -> [21 25 29]
-
-   Remark:
-   This function is only provided as an example for how to write your own
-   interface function.
-
-   Author:
-   Hans Ekkehard Plesser
-
-   SeeAlso: Connect
-*/
-void
-mynest::MyModule::StepPatternConnect_Vi_i_Vi_i_lFunction::execute(
-  SLIInterpreter* i ) const
-{
-  // Check if we have (at least) five arguments on the stack.
-  i->assert_stack_load( 5 );
-
-  // Retrieve source, source step, target, target step from the stack
-  const TokenArray sources =
-    getValue< TokenArray >( i->OStack.pick( 4 ) ); // bottom
-  const long src_step = getValue< long >( i->OStack.pick( 3 ) );
-  const TokenArray targets = getValue< TokenArray >( i->OStack.pick( 2 ) );
-  const long tgt_step = getValue< long >( i->OStack.pick( 1 ) );
-  const Name synmodel_name =
-    getValue< std::string >( i->OStack.pick( 0 ) ); // top
-
-  // Obtain synapse model index
-  const Token synmodel =
-    nest::kernel().model_manager.get_synapsedict()->lookup( synmodel_name );
-  if ( synmodel.empty() )
-    throw nest::UnknownSynapseType( synmodel_name.toString() );
-  const nest::index synmodel_id = static_cast< nest::index >( synmodel );
-
-  // Build a list of targets with the given step
-  TokenArray selected_targets;
-  for ( size_t t = 0; t < targets.size(); t += tgt_step )
-    selected_targets.push_back( targets[ t ] );
-
-  // Now connect all appropriate sources to this list of targets
-  size_t Nconn = 0; // counts connections
-  for ( size_t s = 0; s < sources.size(); s += src_step )
-  {
-    // We must first obtain the GID of the source as integer
-    const nest::long_t sgid = getValue< nest::long_t >( sources[ s ] );
-
-    // nest::kernel().connection_manager.divergent_connect
-    // requires weight and delay arrays. We want to use
-    // default values from the synapse model, so we pass empty arrays.
-    nest::kernel().connection_manager.divergent_connect(
-      sgid, selected_targets, TokenArray(), TokenArray(), synmodel_id );
-    Nconn += selected_targets.size();
-  }
-
-  // We get here only if none of the operations above throws and exception.
-  // Now we can safely remove the arguments from the stack and push Nconn
-  // as our result.
-  i->OStack.pop( 5 );
-  i->OStack.push( Nconn );
-
-  // Finally, we pop the call to this functions from the execution stack.
-  i->EStack.pop();
-}
-
 //-------------------------------------------------------------------------------------
 
 void
@@ -233,13 +127,9 @@ mynest::MyModule::init( SLIInterpreter* i )
     .model_manager.register_connection_model< DropOddSpikeConnection< nest::
         TargetIdentifierPtrRport > >( "drop_odd_synapse" );
 
-  /* Register a SLI function.
-     The first argument is the function name for SLI, the second a pointer to
-     the function object. If you do not want to overload the function in SLI,
-     you do not need to give the mangled name. If you give a mangled name, you
-     should define a type trie in the mymodule-init.sli file.
-  */
-  i->createcommand(
-    "StepPatternConnect_Vi_i_Vi_i_l", &stepPatternConnect_Vi_i_Vi_i_lFunction );
+  // Register connection rule.
+  nest::kernel()
+    .connection_manager.register_conn_builder< StepPatternBuilder >(
+    "step_pattern" );
 
 } // MyModule::init()

--- a/examples/MyModule/mymodule.h
+++ b/examples/MyModule/mymodule.h
@@ -68,28 +68,6 @@ public:
    * module, in particular, set up type tries for functions you have defined.
    */
   const std::string commandstring( void ) const;
-
-public:
-  // Classes implementing your functions -----------------------------
-
-  /**
-   * Implement a function for a step-pattern-based connection.
-   * @note What this function does is described in the SLI documentation
-   *       in the cpp file.
-   * @note The mangled name indicates this function expects the following
-   *       arguments on the stack (bottom first): vector of int, int,
-   *       vector of int, int.
-   * @note You must define a member object in your module class
-   *       of the function class. execute() is later invoked on this
-   *       member.
-   */
-  class StepPatternConnect_Vi_i_Vi_i_lFunction : public SLIFunction
-  {
-  public:
-    void execute( SLIInterpreter* ) const;
-  };
-
-  StepPatternConnect_Vi_i_Vi_i_lFunction stepPatternConnect_Vi_i_Vi_i_lFunction;
 };
 } // namespace mynest
 

--- a/examples/MyModule/sli/mymodule-init.sli
+++ b/examples/MyModule/sli/mymodule-init.sli
@@ -26,8 +26,3 @@
  */
 
 M_DEBUG (mymodule.sli) (Initializing SLI support for MyModule.) message
-
-/StepPatternConnect [ /arraytype /integertype /arraytype /integertype /literaltype ]
-{
-  StepPatternConnect_Vi_i_Vi_i_l
-} def

--- a/examples/MyModule/step_pattern_builder.cpp
+++ b/examples/MyModule/step_pattern_builder.cpp
@@ -1,0 +1,158 @@
+/*
+ *  step_pattern_builder.cpp
+ *
+ *  This file is part of NEST.
+ *
+ *  Copyright (C) 2004 The NEST Initiative
+ *
+ *  NEST is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  NEST is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+// Includes from libnestutil:
+#include "logging.h"
+
+// Includes from nestkernel:
+#include "conn_parameter.h"
+#include "exceptions.h"
+#include "kernel_manager.h"
+#include "nest_names.h"
+#include "node.h"
+#include "vp_manager_impl.h"
+
+// Includes from sli:
+#include "dict.h"
+#include "fdstream.h"
+#include "name.h"
+
+#include "step_pattern_builder.h"
+
+/* BeginDocumentation
+   Name: StepPattern - Rule connecting sources and targets with a step pattern
+
+   Synopsis:
+   source targets << /rule /step_pattern
+                     /source_step M
+                     /target_step N >> << syn spec >> Connect
+
+   Parameters:
+   source_step   - Make connection from every source_step'th neuron
+   target_step   - Make connection to every target_step'th neuron
+
+   Description:
+   This connection rule subsamples the source and target arrays given with
+   step sizes source_step and target_step, beginning with the first element
+   in each array, and connects the selected nodes.
+
+   Example:
+
+   REWRITE
+
+   Remark:
+   This rule is only provided as an example for how to write your own
+   connection rule function.
+
+   Author:
+   Hans Ekkehard Plesser
+
+   SeeAlso: Connect
+*/
+
+
+mynest::StepPatternBuilder::StepPatternBuilder(
+  const nest::GIDCollection& sources,
+  const nest::GIDCollection& targets,
+  const DictionaryDatum& conn_spec,
+  const DictionaryDatum& syn_spec )
+  : nest::ConnBuilder( sources, targets, conn_spec, syn_spec )
+  , source_step_( ( *conn_spec )[ Name( "source_step" ) ] )
+  , target_step_( ( *conn_spec )[ Name( "target_step" ) ] )
+  {
+	if ( source_step_ < 1 )
+	{
+	  throw nest::BadParameter("source_step >= 1 required.");
+	}
+	if ( target_step_ < 1 )
+	{
+	  throw nest::BadParameter("target_step >= 1 required.");
+	}
+  }
+
+void
+mynest::StepPatternBuilder::connect_()
+{
+  // This code is based on AllToAllBuilder, except that we step
+  // by source_step_ and target_step_ except for stepping by 1.
+
+#pragma omp parallel
+  {
+    // get thread id
+    const int tid = nest::kernel().vp_manager.get_thread_id();
+    try
+
+    {
+      // allocate pointer to thread-specific random generator
+      librandom::RngPtr rng = nest::kernel().rng_manager.get_rng( tid );
+
+      for ( nest::GIDCollection::const_iterator tgid = targets_->begin();
+            tgid != targets_->end();
+            tgid = advance_( tgid, targets_->end(), target_step_ ) )
+      {
+        for ( nest::GIDCollection::const_iterator sgid = sources_->begin();
+              sgid != sources_->end();
+              sgid = advance_( sgid, sources_->end(), source_step_ ) )
+        {
+          if ( not autapses_ and *sgid == *tgid )
+          {
+            skip_conn_parameter_( tid );
+            continue;
+          }
+          if ( !change_connected_synaptic_elements( *sgid, *tgid, tid, 1 ) )
+          {
+            for ( nest::GIDCollection::const_iterator sgid = sources_->begin();
+                  sgid != sources_->end();
+                  ++sgid )
+              skip_conn_parameter_( tid );
+            continue;
+          }
+          nest::Node* const target = nest::kernel().node_manager.get_node( *tgid, tid );
+          const nest::thread target_thread = target->get_thread();
+          single_connect_( *sgid, *target, target_thread, rng );
+        }
+      }
+    }
+    catch ( std::exception& err )
+    {
+      // We must create a new exception here, err's lifetime ends at
+      // the end of the catch block.
+      exceptions_raised_.at( tid ) =
+        lockPTR< WrappedThreadException >( new WrappedThreadException( err ) );
+    }
+  }
+}
+
+nest::GIDCollection::const_iterator&
+mynest::StepPatternBuilder::advance_( nest::GIDCollection::const_iterator& it,
+		                              const nest::GIDCollection::const_iterator& end,
+		                              size_t step )
+{
+  while ( step > 0 and it != end )
+  {
+	--step;
+	++it;
+  }
+
+  return it;
+}
+

--- a/examples/MyModule/step_pattern_builder.h
+++ b/examples/MyModule/step_pattern_builder.h
@@ -1,0 +1,67 @@
+/*
+ *  step_pattern_builder.h
+ *
+ *  This file is part of NEST.
+ *
+ *  Copyright (C) 2004 The NEST Initiative
+ *
+ *  NEST is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  NEST is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef STEP_PATTERN_BUILDER_H
+#define STEP_PATTERN_BUILDER_H
+
+// Includes from nestkernel:
+#include "conn_builder.h"
+
+namespace mynest
+{
+
+class StepPatternBuilder : public nest::ConnBuilder
+{
+public:
+  StepPatternBuilder( const nest::GIDCollection& sources,
+    const nest::GIDCollection& targets,
+    const DictionaryDatum& conn_spec,
+    const DictionaryDatum& syn_spec );
+
+protected:
+  void connect_();
+
+private:
+
+  /**
+   * Helper function advancing iterator by step positions.
+   *
+   * Will stop at end of container.
+   *
+   * @param Initial position
+   * @param End of container
+   * @param Number of positions to advance
+   * @return Iterator after advance
+   */
+  static
+  nest::GIDCollection::const_iterator&
+  advance_( nest::GIDCollection::const_iterator&,
+		    const nest::GIDCollection::const_iterator&,
+  		    size_t );
+
+  size_t source_step_;
+  size_t target_step_;
+};
+
+} // namespace mynest
+
+#endif

--- a/examples/MyModule/step_pattern_builder.h
+++ b/examples/MyModule/step_pattern_builder.h
@@ -41,7 +41,6 @@ protected:
   void connect_();
 
 private:
-
   /**
    * Helper function advancing iterator by step positions.
    *
@@ -52,11 +51,10 @@ private:
    * @param Number of positions to advance
    * @return Iterator after advance
    */
-  static
-  nest::GIDCollection::const_iterator&
-  advance_( nest::GIDCollection::const_iterator&,
-		    const nest::GIDCollection::const_iterator&,
-  		    size_t );
+  static nest::GIDCollection::const_iterator& advance_(
+    nest::GIDCollection::const_iterator&,
+    const nest::GIDCollection::const_iterator&,
+    size_t );
 
   size_t source_step_;
   size_t target_step_;

--- a/nestkernel/conn_builder.cpp
+++ b/nestkernel/conn_builder.cpp
@@ -239,7 +239,7 @@ nest::ConnBuilder::~ConnBuilder()
     delete it->second;
 }
 
-inline void
+void
 nest::ConnBuilder::register_parameters_requiring_skipping_(
   ConnParameter& param )
 {
@@ -249,7 +249,7 @@ nest::ConnBuilder::register_parameters_requiring_skipping_(
   }
 }
 
-inline void
+void
 nest::ConnBuilder::check_synapse_params_( std::string syn_name,
   const DictionaryDatum& syn_spec )
 {
@@ -453,7 +453,7 @@ nest::ConnBuilder::disconnect()
       throw WrappedThreadException( *( exceptions_raised_.at( thr ) ) );
 }
 
-inline void
+void
 nest::ConnBuilder::single_connect_( index sgid,
   Node& target,
   thread target_thread,
@@ -577,7 +577,7 @@ nest::ConnBuilder::single_connect_( index sgid,
   }
 }
 
-inline void
+void
 nest::ConnBuilder::skip_conn_parameter_( thread target_thread )
 {
   for ( std::vector< ConnParameter* >::iterator it =
@@ -587,7 +587,7 @@ nest::ConnBuilder::skip_conn_parameter_( thread target_thread )
     ( *it )->skip( target_thread );
 }
 
-inline void
+void
 nest::ConnBuilder::single_disconnect_( index sgid,
   Node& target,
   thread target_thread )

--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -301,7 +301,7 @@ nest::ConnectionManager::connect( const GIDCollection& sources,
 
   if ( !connruledict_->known( rule_name ) )
     throw BadProperty(
-      String::compose( "Unknown connectivty rule: %s", rule_name ) );
+      String::compose( "Unknown connectivity rule: %1", rule_name ) );
   const long rule_id = ( *connruledict_ )[ rule_name ];
 
   ConnBuilder* cb = connbuilder_factories_.at( rule_id )->create(


### PR DESCRIPTION
@jakobj I have now completely rewritten the connection component of MyModule so that it is based on ConnBuilder. With that, the last `divergent_connect()` that is unrelated to `DataConnect` should be gone.