### PR TITLE
Feature/mpi cleanup

### DIFF
--- a/nestkernel/CMakeLists.txt
+++ b/nestkernel/CMakeLists.txt
@@ -84,7 +84,7 @@ set( nestkernel_sources
     manager_interface.h
     target_table.h target_table.cpp
     target_table_devices.h target_table_devices.cpp target_table_devices_impl.h
-    target.h target_data.h
+    target.h target_data.h is_legal.h
     send_buffer_position.h
     source.h
     source_table.h source_table.cpp

--- a/nestkernel/event_delivery_manager.h
+++ b/nestkernel/event_delivery_manager.h
@@ -449,8 +449,8 @@ private:
   std::vector< OffGridSpikeData > send_buffer_off_grid_spike_data_;
   std::vector< OffGridSpikeData > recv_buffer_off_grid_spike_data_;
 
-  TargetData* send_buffer_target_data_;
-  TargetData* recv_buffer_target_data_;
+  std::vector<TargetData> send_buffer_target_data_;
+  std::vector<TargetData> recv_buffer_target_data_;
 
   bool buffer_size_target_data_has_changed_; //!< whether size of MPI buffer for
                                              //communication of connections was

--- a/nestkernel/is_legal.h
+++ b/nestkernel/is_legal.h
@@ -1,0 +1,12 @@
+#ifndef IS_LEGAL
+#define IS_LEGAL
+
+namespace nest {
+template<bool L>
+struct IsLegal {};
+
+template<>
+struct IsLegal<true> {typedef void* is_legal;};
+}
+
+#endif //IS_LEGAL

--- a/nestkernel/is_legal.h
+++ b/nestkernel/is_legal.h
@@ -1,3 +1,25 @@
+/*
+ *  is_legal.h
+ *
+ *  This file is part of NEST.
+ *
+ *  Copyright (C) 2004 The NEST Initiative
+ *
+ *  NEST is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  NEST is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
 #ifndef IS_LEGAL
 #define IS_LEGAL
 

--- a/nestkernel/mpi_manager.cpp
+++ b/nestkernel/mpi_manager.cpp
@@ -747,11 +747,9 @@ nest::MPIManager::communicate_Allgather( std::vector< long >& buffer )
   MPI_Allgather( &my_val, 1, MPI_LONG, &buffer[ 0 ], 1, MPI_LONG, comm );
 }
 
-
-// TODO@5g: create non-MPI counterpart
 void
-nest::MPIManager::communicate_Alltoall( unsigned int* send_buffer,
-  unsigned int* recv_buffer,
+nest::MPIManager::communicate_Alltoall_( void* send_buffer,
+  void* recv_buffer,
   const unsigned int send_recv_count )
 {
   MPI_Alltoall( send_buffer,
@@ -763,31 +761,11 @@ nest::MPIManager::communicate_Alltoall( unsigned int* send_buffer,
     comm );
 }
 
-void
-nest::MPIManager::communicate_target_data_Alltoall( unsigned int* send_buffer,
-  unsigned int* recv_buffer )
-{
-  communicate_Alltoall( send_buffer, recv_buffer, send_recv_count_target_data_in_int_per_rank_ );
-}
 
 void
-nest::MPIManager::communicate_spike_data_Alltoall( unsigned int* send_buffer,
-  unsigned int* recv_buffer )
-{
-  communicate_Alltoall( send_buffer, recv_buffer, send_recv_count_spike_data_in_int_per_rank_ );
-}
-
-void
-nest::MPIManager::communicate_off_grid_spike_data_Alltoall( unsigned int* send_buffer,
-  unsigned int* recv_buffer )
-{
-  communicate_Alltoall( send_buffer, recv_buffer, send_recv_count_off_grid_spike_data_in_int_per_rank_ );
-}
-
-void
-nest::MPIManager::communicate_secondary_events_Alltoall(
-  unsigned int* send_buffer,
-  unsigned int* recv_buffer )
+nest::MPIManager::communicate_secondary_events_Alltoall_(
+  void* send_buffer,
+  void* recv_buffer )
 {
   MPI_Alltoall( send_buffer,
     chunk_size_secondary_events_in_int_,
@@ -1254,41 +1232,6 @@ nest::MPIManager::communicate_Allreduce_sum( std::vector< double >& send_buffer,
   std::vector< double >& recv_buffer )
 {
   recv_buffer.swap( send_buffer );
-}
-
-//////////////////////////////////////
-
-void
-nest::MPIManager::communicate_target_data_Alltoall( unsigned int* send_buffer,
-  unsigned int* recv_buffer )
-{
-    // null op is to transfer from send_buffer to recv_buffer
-    memmove(recv_buffer, send_buffer, send_recv_count_target_data_in_int_per_rank_ * sizeof(recv_buffer[0]) );
-}
-
-void
-nest::MPIManager::communicate_spike_data_Alltoall( unsigned int* send_buffer,
-  unsigned int* recv_buffer )
-{
-    // null op is to transfer from send_buffer to recv_buffer
-    memmove(recv_buffer, send_buffer, send_recv_count_spike_data_in_int_per_rank_ * sizeof(recv_buffer[0]));
-}
-
-void
-nest::MPIManager::communicate_off_grid_spike_data_Alltoall( unsigned int* send_buffer,
-  unsigned int* recv_buffer )
-{
-    // null op is to transfer from send_buffer to recv_buffer
-    memmove(recv_buffer, send_buffer, send_recv_count_off_grid_spike_data_in_int_per_rank_ * sizeof(recv_buffer[0]));
-}
-
-void
-nest::MPIManager::communicate_secondary_events_Alltoall(
-  unsigned int* send_buffer,
-  unsigned int* recv_buffer )
-{
-        // null op is to transfer from send_buffer to recv_buffer
-    memmove(recv_buffer, send_buffer, chunk_size_secondary_events_in_int_ * sizeof(recv_buffer[0]));
 }
 
 void

--- a/nestkernel/source_table.cpp
+++ b/nestkernel/source_table.cpp
@@ -483,14 +483,15 @@ nest::SourceTable::get_next_target_data( const thread tid,
       {
         next_target_data.set_is_primary( true );
         // we store the thread index of the source table, not our own tid!
-        next_target_data.set_tid( current_position.tid );
-        next_target_data.set_syn_id(
-          current_position.syn_id );
-        next_target_data.set_lcid( current_position.lcid );
+        TargetDataFields& target_fields = next_target_data.target_data;
+        target_fields.set_tid( current_position.tid );
+        target_fields.set_syn_id(current_position.syn_id );
+        target_fields.set_lcid( current_position.lcid );
       }
       else
       {
         next_target_data.set_is_primary( false );
+
         const size_t recv_buffer_pos =
           kernel().connection_manager.get_secondary_recv_buffer_position(
             current_position.tid,
@@ -501,10 +502,10 @@ nest::SourceTable::get_next_target_data( const thread tid,
         // according to buffer layout of MPIAlltoall
         const size_t send_buffer_pos = kernel().mpi_manager.recv_buffer_pos_to_send_buffer_pos_secondary_events( recv_buffer_pos, source_rank );
 
-        reinterpret_cast< SecondaryTargetData* >( &next_target_data )
-          ->set_send_buffer_pos( send_buffer_pos );
-        reinterpret_cast< SecondaryTargetData* >( &next_target_data )
-          ->set_syn_id( current_position.syn_id );
+        SecondaryTargetDataFields& secondary_fields
+            = next_target_data.secondary_data;
+        secondary_fields.set_send_buffer_pos( send_buffer_pos );
+        secondary_fields.set_syn_id( current_position.syn_id );
       }
       --current_position.lcid;
       return true; // found a valid entry

--- a/nestkernel/target.h
+++ b/nestkernel/target.h
@@ -28,6 +28,7 @@
 
 // Includes from nestkernel:
 #include "nest_types.h"
+#include "is_legal.h"
 
 namespace nest
 {
@@ -66,14 +67,6 @@ private:
   static const int max_tid_ = 1024; // 2 ** 10
   static const int max_syn_id_ = 64; // 2 ** 6
 
-  //!< check legal size
-  static struct StaticAssert {
-      StaticAssert() {
-        assert( sizeof( Target ) == 8 );
-      }
-  } static_assert_sizes;
-
-
 public:
   Target();
   Target( const Target& target );
@@ -93,6 +86,10 @@ public:
   bool is_processed() const;
   double get_offset() const;
 };
+
+//!< check legal size
+static const IsLegal<sizeof(Target) == 8>::is_legal
+    success_target_size = NULL;
 
 inline Target::Target()
   : data_( 0 )

--- a/nestkernel/target.h
+++ b/nestkernel/target.h
@@ -66,6 +66,14 @@ private:
   static const int max_tid_ = 1024; // 2 ** 10
   static const int max_syn_id_ = 64; // 2 ** 6
 
+  //!< check legal size
+  static struct StaticAssert {
+      StaticAssert() {
+        assert( sizeof( Target ) == 8 );
+      }
+  } static_assert_sizes;
+
+
 public:
   Target();
   Target( const Target& target );

--- a/nestkernel/target_data.h
+++ b/nestkernel/target_data.h
@@ -72,11 +72,9 @@ public:
   bool is_primary() const;
 };
 
+// Just to set protected: members must always be
+// explicitly set
 inline TargetDataBase::TargetDataBase()
-  : source_lid_( 0 )
-  , source_tid_( 0 )
-  , marker_( default_marker_ )
-  , is_primary_( true )
 {
 }
 
@@ -172,7 +170,8 @@ private:
   unsigned int syn_id_ : 8;
 
 public:
-  TargetData();
+  // Members must be set explicitly -- no defaults
+  // Done this way to create large vector without preconstruction
   void set_lcid( const index lcid );
   index get_lcid() const;
   void set_tid( const thread tid );
@@ -180,14 +179,6 @@ public:
   void set_syn_id( const synindex syn_id );
   synindex get_syn_id() const;
 };
-
-inline TargetData::TargetData()
-  : TargetDataBase()
-  , lcid_( 0 )
-  , tid_( 0 )
-  , syn_id_( 0 )
-{
-}
 
 inline void
 TargetData::set_lcid( const index lcid )
@@ -232,19 +223,13 @@ private:
   unsigned char syn_id_;
 
 public:
-  SecondaryTargetData();
+  // Members must be set explicitly -- no defaults
+  // Done this way to create large vector without preconstruction
   void set_send_buffer_pos( const size_t pos );
   size_t get_send_buffer_pos() const;
   void set_syn_id( const synindex syn_id );
   synindex get_syn_id() const;
 };
-
-inline SecondaryTargetData::SecondaryTargetData()
-  : TargetDataBase()
-  , send_buffer_pos_( std::numeric_limits< unsigned int >::max() - 1 )
-  , syn_id_( std::numeric_limits< unsigned char >::max() - 1 )
-{
-}
 
 inline void
 SecondaryTargetData::set_send_buffer_pos( const size_t pos )

--- a/nestkernel/target_data.h
+++ b/nestkernel/target_data.h
@@ -148,6 +148,15 @@ private:
   unsigned int marker_ : 2;
   bool is_primary_ : 1; //!< TargetData has TargetDataFields
                         //!< else has SecondaryTargetDataFields
+
+  //!< check legal size
+  static struct StaticAssert {
+      StaticAssert() {
+        assert( sizeof( TargetData ) == 12 );
+        //assert( sizeof( SecondaryTargetDataFields ) == 12 );
+      }
+  } static_assert_sizes;
+
 public:
   //<! variant fields
   union {
@@ -155,6 +164,7 @@ public:
       SecondaryTargetDataFields secondary_data;
   };
 
+  
   void reset_marker();
   void set_complete_marker();
   void set_end_marker();

--- a/nestkernel/target_data.h
+++ b/nestkernel/target_data.h
@@ -29,6 +29,7 @@
 // Includes from nestkernel:
 #include "nest_types.h"
 #include "target.h"
+#include "is_legal.h"
 
 namespace nest
 {
@@ -149,21 +150,12 @@ private:
   bool is_primary_ : 1; //!< TargetData has TargetDataFields
                         //!< else has SecondaryTargetDataFields
 
-  //!< check legal size
-  static struct StaticAssert {
-      StaticAssert() {
-        assert( sizeof( TargetData ) == 12 );
-        //assert( sizeof( SecondaryTargetDataFields ) == 12 );
-      }
-  } static_assert_sizes;
-
 public:
   //<! variant fields
   union {
       TargetDataFields target_data;
       SecondaryTargetDataFields secondary_data;
   };
-
   
   void reset_marker();
   void set_complete_marker();
@@ -179,6 +171,12 @@ public:
   void set_is_primary( const bool is_primary );
   bool is_primary() const;
 };
+
+//!< check legal size
+static const IsLegal<sizeof(TargetData) == 12>::is_legal
+    success_target_data_size = NULL;
+//assert( sizeof( SecondaryTargetDataFields ) == 12 );
+
 
 inline void
 TargetData::reset_marker()

--- a/nestkernel/target_data.h
+++ b/nestkernel/target_data.h
@@ -32,6 +32,98 @@
 
 namespace nest
 {
+class TargetDataFields
+{
+private:
+  unsigned int lcid_ : 27;
+  unsigned int tid_ : 10;
+  unsigned int syn_id_ : 8;
+
+public:
+  // Members must be set explicitly -- no defaults
+  void set_lcid( const index lcid );
+  index get_lcid() const;
+  void set_tid( const thread tid );
+  thread get_tid() const;
+  void set_syn_id( const synindex syn_id );
+  synindex get_syn_id() const;
+};
+
+inline void
+TargetDataFields::set_lcid( const index lcid )
+{
+  lcid_ = lcid;
+}
+
+inline index
+TargetDataFields::get_lcid() const
+{
+  return lcid_;
+}
+
+inline void
+TargetDataFields::set_tid( const thread tid )
+{
+  tid_ = tid;
+}
+
+inline thread
+TargetDataFields::get_tid() const
+{
+  return tid_;
+}
+
+inline void
+TargetDataFields::set_syn_id( const synindex syn_id )
+{
+  syn_id_ = syn_id;
+}
+
+inline synindex
+TargetDataFields::get_syn_id() const
+{
+  return syn_id_;
+}
+
+class SecondaryTargetDataFields
+{
+private:
+  unsigned int send_buffer_pos_;
+  unsigned char syn_id_;
+
+public:
+  // Members must be set explicitly -- no defaults
+  void set_send_buffer_pos( const size_t pos );
+  size_t get_send_buffer_pos() const;
+  void set_syn_id( const synindex syn_id );
+  synindex get_syn_id() const;
+};
+
+inline void
+SecondaryTargetDataFields::set_send_buffer_pos( const size_t pos )
+{
+  assert( pos < std::numeric_limits< unsigned int >::max() );
+  send_buffer_pos_ = pos;
+}
+
+inline size_t
+SecondaryTargetDataFields::get_send_buffer_pos() const
+{
+  return send_buffer_pos_;
+}
+
+inline void
+SecondaryTargetDataFields::set_syn_id( const synindex syn_id )
+{
+  assert( syn_id < std::numeric_limits< unsigned char >::max() );
+  syn_id_ = syn_id;
+}
+
+inline synindex
+SecondaryTargetDataFields::get_syn_id() const
+{
+  return syn_id_;
+}
 
 /**
  * Used to communicate part of the connection infrastructure from
@@ -39,8 +131,12 @@ namespace nest
  * buffers.
  * SeeAlso: SpikeData
  */
-class TargetDataBase
+class TargetData
 {
+    // Members must be set explicitly -- no defaults
+    // Done this way to create large vector without preconstruction
+    // and to handle variant fields
+    
 private:
   static const unsigned int default_marker_ = 0;
   static const unsigned int complete_marker_ = 1;
@@ -50,13 +146,15 @@ private:
   unsigned int source_lid_ : 19; //!< local id of presynaptic neuron
   unsigned int source_tid_ : 10; //!< thread index of presynaptic neuron
   unsigned int marker_ : 2;
-  bool is_primary_ : 1;
-
-protected:
-  TargetDataBase();
-
+  bool is_primary_ : 1; //!< TargetData has TargetDataFields
+                        //!< else has SecondaryTargetDataFields
 public:
-  ~TargetDataBase();
+  //<! variant fields
+  union {
+      TargetDataFields target_data;
+      SecondaryTargetDataFields secondary_data;
+  };
+
   void reset_marker();
   void set_complete_marker();
   void set_end_marker();
@@ -72,191 +170,85 @@ public:
   bool is_primary() const;
 };
 
-// Just to set protected: members must always be
-// explicitly set
-inline TargetDataBase::TargetDataBase()
-{
-}
-
-inline TargetDataBase::~TargetDataBase()
-{
-}
-
 inline void
-TargetDataBase::reset_marker()
+TargetData::reset_marker()
 {
   marker_ = default_marker_;
 }
 
 inline void
-TargetDataBase::set_complete_marker()
+TargetData::set_complete_marker()
 {
   marker_ = complete_marker_;
 }
 
 inline void
-TargetDataBase::set_end_marker()
+TargetData::set_end_marker()
 {
   marker_ = end_marker_;
 }
 
 inline void
-TargetDataBase::set_invalid_marker()
+TargetData::set_invalid_marker()
 {
   marker_ = invalid_marker_;
 }
 
 inline bool
-TargetDataBase::is_complete_marker() const
+TargetData::is_complete_marker() const
 {
   return marker_ == complete_marker_;
 }
 
 inline bool
-TargetDataBase::is_end_marker() const
+TargetData::is_end_marker() const
 {
   return marker_ == end_marker_;
 }
 
 inline bool
-TargetDataBase::is_invalid_marker() const
+TargetData::is_invalid_marker() const
 {
   return marker_ == invalid_marker_;
 }
 
 inline void
-TargetDataBase::set_source_lid( const index source_lid )
+TargetData::set_source_lid( const index source_lid )
 {
   assert( source_lid < 1048576 );
   source_lid_ = source_lid;
 }
 
 inline void
-TargetDataBase::set_source_tid( const thread source_tid )
+TargetData::set_source_tid( const thread source_tid )
 {
   assert( source_tid < 1024 );
   source_tid_ = source_tid;
 }
 
 inline index
-TargetDataBase::get_source_lid() const
+TargetData::get_source_lid() const
 {
   return source_lid_;
 }
 
 inline thread
-TargetDataBase::get_source_tid() const
+TargetData::get_source_tid() const
 {
   return source_tid_;
 }
 
 inline void
-TargetDataBase::set_is_primary( const bool is_primary )
+TargetData::set_is_primary( const bool is_primary )
 {
   is_primary_ = is_primary;
 }
 
 inline bool
-TargetDataBase::is_primary() const
+TargetData::is_primary() const
 {
   return is_primary_;
 }
-
-class TargetData : public TargetDataBase
-{
-private:
-  unsigned int lcid_ : 27;
-  unsigned int tid_ : 10;
-  unsigned int syn_id_ : 8;
-
-public:
-  // Members must be set explicitly -- no defaults
-  // Done this way to create large vector without preconstruction
-  void set_lcid( const index lcid );
-  index get_lcid() const;
-  void set_tid( const thread tid );
-  thread get_tid() const;
-  void set_syn_id( const synindex syn_id );
-  synindex get_syn_id() const;
-};
-
-inline void
-TargetData::set_lcid( const index lcid )
-{
-  lcid_ = lcid;
-}
-
-inline index
-TargetData::get_lcid() const
-{
-  return lcid_;
-}
-
-inline void
-TargetData::set_tid( const thread tid )
-{
-  tid_ = tid;
-}
-
-inline thread
-TargetData::get_tid() const
-{
-  return tid_;
-}
-
-inline void
-TargetData::set_syn_id( const synindex syn_id )
-{
-  syn_id_ = syn_id;
-}
-
-inline synindex
-TargetData::get_syn_id() const
-{
-  return syn_id_;
-}
-
-class SecondaryTargetData : public TargetDataBase
-{
-private:
-  unsigned int send_buffer_pos_;
-  unsigned char syn_id_;
-
-public:
-  // Members must be set explicitly -- no defaults
-  // Done this way to create large vector without preconstruction
-  void set_send_buffer_pos( const size_t pos );
-  size_t get_send_buffer_pos() const;
-  void set_syn_id( const synindex syn_id );
-  synindex get_syn_id() const;
-};
-
-inline void
-SecondaryTargetData::set_send_buffer_pos( const size_t pos )
-{
-  assert( pos < std::numeric_limits< unsigned int >::max() );
-  send_buffer_pos_ = pos;
-}
-
-inline size_t
-SecondaryTargetData::get_send_buffer_pos() const
-{
-  return send_buffer_pos_;
-}
-
-inline void
-SecondaryTargetData::set_syn_id( const synindex syn_id )
-{
-  assert( syn_id < std::numeric_limits< unsigned char >::max() );
-  syn_id_ = syn_id;
-}
-
-inline synindex
-SecondaryTargetData::get_syn_id() const
-{
-  return syn_id_;
-}
-
 } // namespace nest
 
 #endif // TARGET_DATA_H

--- a/nestkernel/target_table.cpp
+++ b/nestkernel/target_table.cpp
@@ -29,7 +29,7 @@ nest::TargetTable::TargetTable()
 {
   assert( sizeof( Target ) == 8 );
   assert( sizeof( TargetData ) == 12 );
-  assert( sizeof( SecondaryTargetData ) == 12 );
+  //assert( sizeof( SecondaryTargetDataFields ) == 12 );
 }
 
 nest::TargetTable::~TargetTable()
@@ -125,17 +125,22 @@ nest::TargetTable::add_target( const thread tid, const thread target_rank, const
 
   if ( target_data.is_primary() )
   {
+    const TargetDataFields& target_fields = target_data.target_data;
+
     ( *targets_[ tid ] )[ lid ].push_back(
-      Target( target_data.get_tid(), target_rank, target_data.get_syn_id(), target_data.get_lcid() ) );
+      Target( target_fields.get_tid(),
+              target_rank,
+              target_fields.get_syn_id(),
+              target_fields.get_lcid() ) );
   }
   else
   {
+    const SecondaryTargetDataFields& secondary_fields =
+        target_data.secondary_data;
     const size_t send_buffer_pos =
-      reinterpret_cast< const SecondaryTargetData* >( &target_data )
-        ->get_send_buffer_pos();
+      secondary_fields.get_send_buffer_pos();
     const synindex syn_id =
-      reinterpret_cast< const SecondaryTargetData* >( &target_data )
-        ->get_syn_id();
+      secondary_fields.get_syn_id();
 
     assert( syn_id < ( *secondary_send_buffer_pos_[ tid ] )[ lid ].size() );
     ( *secondary_send_buffer_pos_[ tid ] )[ lid ][ syn_id ].push_back(

--- a/nestkernel/target_table.cpp
+++ b/nestkernel/target_table.cpp
@@ -25,17 +25,6 @@
 // Includes from nestkernel:
 #include "kernel_manager.h"
 
-nest::TargetTable::TargetTable()
-{
-  assert( sizeof( Target ) == 8 );
-  assert( sizeof( TargetData ) == 12 );
-  //assert( sizeof( SecondaryTargetDataFields ) == 12 );
-}
-
-nest::TargetTable::~TargetTable()
-{
-}
-
 void
 nest::TargetTable::initialize()
 {

--- a/nestkernel/target_table.h
+++ b/nestkernel/target_table.h
@@ -65,9 +65,6 @@ private:
     secondary_send_buffer_pos_;
 
 public:
-  TargetTable();
-  ~TargetTable();
-
   //! initialize data structures
   void initialize();
 


### PR DESCRIPTION
Use vectors for mpi communicator interface for 5g
For none-mpi, use vector.swap() to exchange data with self (double-buffering)
Use variant/union for TargetData and SecondaryTargetData packets
Do compile time check for TargetData and Target size

Fix issue #30, extends #7 and #25 