### PR TITLE
Make C++ tests run with installcheck

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -95,6 +95,9 @@ before_install:
   # Required for building cppcheck-1.69.
   - sudo apt-get install -y libpcre3 libpcre3-dev
 
+  # Install boost libraries required for cpp test suite
+  - sudo apt-get install -y libboost-test-dev
+
   # Install jq to process JSON output from GitHub API.
   - sudo apt-get install -y jq
 

--- a/build.sh
+++ b/build.sh
@@ -208,6 +208,7 @@ cmake \
   -DCMAKE_INSTALL_PREFIX="$NEST_RESULT" \
   -Dwith-optimize=ON \
   -Dwith-warning=ON \
+  -Dwith-boost=ON \
   $CONFIGURE_THREADING \
   $CONFIGURE_MPI \
   $CONFIGURE_PYTHON \

--- a/testsuite/cpptests/test_sort.h
+++ b/testsuite/cpptests/test_sort.h
@@ -36,6 +36,20 @@
 namespace nest
 {
 
+const bool
+is_sorted( std::vector< size_t >::const_iterator begin,
+  std::vector< size_t >::const_iterator end )
+{
+  for ( std::vector< size_t >::const_iterator it = begin; it < --end; )
+  {
+    if ( *it > *( ++it ) )
+    {
+      return false;
+    }
+  }
+  return true;
+}
+
 BOOST_AUTO_TEST_SUITE( test_sort )
 
 BOOST_AUTO_TEST_CASE( test_random )
@@ -53,8 +67,8 @@ BOOST_AUTO_TEST_CASE( test_random )
   
   sort::sort( vec0, vec1 );
 
-  BOOST_CHECK( std::is_sorted( vec0.begin(), vec0.end() ) );
-  BOOST_CHECK( std::is_sorted( vec1.begin(), vec1.end() ) );
+  BOOST_REQUIRE( is_sorted( vec0.begin(), vec0.end() ) );
+  BOOST_REQUIRE( is_sorted( vec1.begin(), vec1.end() ) );
 }
 
 BOOST_AUTO_TEST_CASE( test_linear )
@@ -71,8 +85,8 @@ BOOST_AUTO_TEST_CASE( test_linear )
 
   sort::sort( vec0, vec1 );
 
-  BOOST_CHECK( std::is_sorted( vec0.begin(), vec0.end() ) );
-  BOOST_CHECK( std::is_sorted( vec1.begin(), vec1.end() ) );
+  BOOST_REQUIRE( is_sorted( vec0.begin(), vec0.end() ) );
+  BOOST_REQUIRE( is_sorted( vec1.begin(), vec1.end() ) );
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/testsuite/do_tests.sh.in
+++ b/testsuite/do_tests.sh.in
@@ -798,6 +798,20 @@ else
 fi
 
 echo
+echo "Phase 8: Running C++ tests"
+echo "--------------------------"
+
+CPP_TEST_OUTPUT="$(run_all_cpptests 2>&1)"
+echo "$CPP_TEST_OUTPUT"
+CPP_TEST_TOTAL=$(echo "$CPP_TEST_OUTPUT" | sed -nr 's/.*Running ([0-9]+).*/\1/p')
+CPP_TEST_FAILED=$(echo "$CPP_TEST_OUTPUT" | sed -nr 's/.*([0-9]+) failure.*/\1/p')
+[ -z "$CPP_TEST_FAILED" ] && CPP_TEST_FAILED=0
+CPP_TEST_PASS=$(( $CPP_TEST_TOTAL - $CPP_TEST_FAILED ))
+TEST_TOTAL=$(( $TEST_TOTAL + $CPP_TEST_TOTAL ))
+TEST_PASSED=$(( $TEST_PASSED + $CPP_TEST_PASS ))
+TEST_FAILED=$(( $TEST_FAILED + $CPP_TEST_FAILED ))
+
+echo
 echo "NEST Testsuite Summary"
 echo "----------------------"
 echo "  NEST Executable: $(which nest)"


### PR DESCRIPTION
Adds the C++ tests to installcheck. NEST is now always installed with Boost on Travis. Had to replace `std::is_sorted` because it's C++11, and using `BOOST_REQUIRE` to make test cases fail on the first failing check to not mess up the test count.