### PR TITLE
Remove all _5g suffixes from variable/function names

### DIFF
--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -224,8 +224,7 @@ nest::ConnectionManager::get_synapse_status( const index source_gid,
          and not target->local_receiver()
          and ( *connections_[ tid ] )[ syn_id ] != NULL ) ) )
   {
-    ( *connections_[ tid ] )[ syn_id ]->get_synapse_status(
-      tid, lcid, dict );
+    ( *connections_[ tid ] )[ syn_id ]->get_synapse_status( tid, lcid, dict );
   }
   else if ( source->has_proxies() and not target->has_proxies()
     and target->local_receiver() )
@@ -657,8 +656,7 @@ nest::ConnectionManager::connect_( Node& s,
 
   kernel()
     .model_manager.get_synapse_prototype( syn_id, tid )
-    .add_connection(
-      s, r, connections_[ tid ], syn_id, params, delay, weight );
+    .add_connection( s, r, connections_[ tid ], syn_id, params, delay, weight );
   source_table_.add_source( tid, syn_id, s_gid, is_primary );
 
   increase_connection_count( tid, syn_id );

--- a/nestkernel/connection_manager.h
+++ b/nestkernel/connection_manager.h
@@ -150,7 +150,7 @@ public:
     const index sgid,
     const index tgid );
 
-  void disconnect_5g( const thread tid,
+  void disconnect( const thread tid,
     const synindex syn_id,
     const index sgid,
     const index tgid );
@@ -277,9 +277,7 @@ public:
 
   bool get_user_set_delay_extrema() const;
 
-  void send( thread t, index sgid, Event& e );
-
-  void send_5g( const thread tid,
+  void send( const thread tid,
     const synindex syn_id,
     const index lcid,
     const std::vector< ConnectorModel* >& cm,
@@ -469,7 +467,7 @@ private:
   /**
    * Deletes all connections.
    */
-  void delete_connections_5g_();
+  void delete_connections_();
 
   /**
    * connect_ is used to establish a connection between a sender and
@@ -562,7 +560,7 @@ private:
    * connection information. Corresponds to a three dimensional
    * structure: threads|synapses|connections
    */
-  std::vector< std::vector< ConnectorBase* >* > connections_5g_;
+  std::vector< std::vector< ConnectorBase* >* > connections_;
 
   /**
    * A structure to hold the global ids of presynaptic neurons during
@@ -787,7 +785,7 @@ inline size_t
 ConnectionManager::get_num_connections_( const thread tid,
   const synindex syn_id ) const
 {
-  return ( *connections_5g_[ tid ] )[ syn_id ]->size();
+  return ( *connections_[ tid ] )[ syn_id ]->size();
 }
 
 inline index

--- a/nestkernel/connection_manager_impl.h
+++ b/nestkernel/connection_manager_impl.h
@@ -55,17 +55,17 @@ ConnectionManager::get_target_gid( const thread tid,
   const synindex syn_id,
   const index lcid ) const
 {
-  return ( *connections_5g_[ tid ] )[ syn_id ]->get_target_gid( tid, lcid );
+  return ( *connections_[ tid ] )[ syn_id ]->get_target_gid( tid, lcid );
 }
 
 inline void
-ConnectionManager::send_5g( const thread tid,
+ConnectionManager::send( const thread tid,
   const synindex syn_id,
   const index lcid,
   const std::vector< ConnectorModel* >& cm,
   Event& e )
 {
-  ( *connections_5g_[ tid ] )[ syn_id ]->send( tid, syn_id, lcid, cm, e );
+  ( *connections_[ tid ] )[ syn_id ]->send( tid, syn_id, lcid, cm, e );
 }
 
 inline void
@@ -101,7 +101,7 @@ ConnectionManager::set_has_source_subsequent_targets( const thread tid,
   const index lcid,
   const bool subsequent_targets )
 {
-  ( *connections_5g_[ tid ] )[ syn_id ]->set_has_source_subsequent_targets(
+  ( *connections_[ tid ] )[ syn_id ]->set_has_source_subsequent_targets(
     lcid, subsequent_targets );
 }
 

--- a/nestkernel/connector_model.h
+++ b/nestkernel/connector_model.h
@@ -75,7 +75,7 @@ public:
    * omitted, NAN indicates this and weight/delay are set only if they are
    * valid.
    */
-  virtual void add_connection_5g( Node& src,
+  virtual void add_connection( Node& src,
     Node& tgt,
     std::vector< ConnectorBase* >* hetconn,
     const synindex syn_id,
@@ -194,7 +194,7 @@ public:
   {
   }
 
-  void add_connection_5g( Node& src,
+  void add_connection( Node& src,
     Node& tgt,
     std::vector< ConnectorBase* >* hetconn,
     const synindex syn_id,
@@ -252,7 +252,7 @@ public:
 private:
   void used_default_delay();
 
-  void add_connection_5g_( Node& src,
+  void add_connection_( Node& src,
     Node& tgt,
     std::vector< ConnectorBase* >* hetconn,
     const synindex syn_id,

--- a/nestkernel/connector_model_impl.h
+++ b/nestkernel/connector_model_impl.h
@@ -181,7 +181,7 @@ GenericConnectorModel< ConnectionT >::set_syn_id( synindex syn_id )
 
 template < typename ConnectionT >
 void
-GenericConnectorModel< ConnectionT >::add_connection_5g( Node& src,
+GenericConnectorModel< ConnectionT >::add_connection( Node& src,
   Node& tgt,
   std::vector< ConnectorBase* >* thread_local_connectors,
   const synindex syn_id,
@@ -254,7 +254,7 @@ GenericConnectorModel< ConnectionT >::add_connection_5g( Node& src,
 #endif
   updateValue< long >( p, names::receptor_type, actual_receptor_type );
 
-  add_connection_5g_( src,
+  add_connection_( src,
     tgt,
     thread_local_connectors,
     syn_id,
@@ -265,7 +265,7 @@ GenericConnectorModel< ConnectionT >::add_connection_5g( Node& src,
 
 template < typename ConnectionT >
 void
-GenericConnectorModel< ConnectionT >::add_connection_5g_( Node& src,
+GenericConnectorModel< ConnectionT >::add_connection_( Node& src,
   Node& tgt,
   std::vector< ConnectorBase* >* thread_local_connectors,
   const synindex syn_id,

--- a/nestkernel/event_delivery_manager.cpp
+++ b/nestkernel/event_delivery_manager.cpp
@@ -415,11 +415,8 @@ EventDeliveryManager::gather_spike_data_( const thread tid,
       kernel().mpi_manager.get_send_recv_count_spike_data_per_rank() );
 
     // collocate spikes to send buffer
-    me_completed_tid = collocate_spike_data_buffers_( tid,
-      assigned_ranks,
-      send_buffer_position,
-      spike_register_,
-      send_buffer );
+    me_completed_tid = collocate_spike_data_buffers_(
+      tid, assigned_ranks, send_buffer_position, spike_register_, send_buffer );
 
     if ( off_grid_spiking_ )
     {

--- a/nestkernel/event_delivery_manager.cpp
+++ b/nestkernel/event_delivery_manager.cpp
@@ -66,7 +66,7 @@ EventDeliveryManager::EventDeliveryManager()
   comm_steps_spike_data = 0;
   comm_rounds_spike_data = 0;
   comm_steps_secondary_events = 0;
-  call_count_deliver_events_5g = std::vector< unsigned int >();
+  call_count_deliver_events = std::vector< unsigned int >();
 #endif
 }
 
@@ -82,32 +82,32 @@ EventDeliveryManager::initialize()
   init_moduli();
   local_spike_counter_.resize( num_threads, 0 );
   reset_timers_counters();
-  spike_register_5g_.resize( num_threads, NULL );
-  off_grid_spike_register_5g_.resize( num_threads, NULL );
+  spike_register_.resize( num_threads, NULL );
+  off_grid_spike_register_.resize( num_threads, NULL );
   completed_count_.resize( num_threads, 0 );
 #ifndef DISABLE_COUNTS
-  call_count_deliver_events_5g.resize( num_threads, 0 ); // TODO@5g: remove
+  call_count_deliver_events.resize( num_threads, 0 ); // TODO@5g: remove
 #endif
 
 #pragma omp parallel
   {
     const thread tid = kernel().vp_manager.get_thread_id();
-    if ( spike_register_5g_[ tid ] != 0 )
+    if ( spike_register_[ tid ] != 0 )
     {
-      delete ( spike_register_5g_[ tid ] );
+      delete ( spike_register_[ tid ] );
     }
-    spike_register_5g_[ tid ] =
+    spike_register_[ tid ] =
       new std::vector< std::vector< std::vector< Target > > >(
         num_threads,
         std::vector< std::vector< Target > >(
           kernel().connection_manager.get_min_delay(),
           std::vector< Target >( 0 ) ) );
 
-    if ( off_grid_spike_register_5g_[ tid ] != 0 )
+    if ( off_grid_spike_register_[ tid ] != 0 )
     {
-      delete ( off_grid_spike_register_5g_[ tid ] );
+      delete ( off_grid_spike_register_[ tid ] );
     }
-    off_grid_spike_register_5g_[ tid ] =
+    off_grid_spike_register_[ tid ] =
       new std::vector< std::vector< std::vector< OffGridTarget > > >(
         num_threads,
         std::vector< std::vector< OffGridTarget > >(
@@ -121,23 +121,23 @@ EventDeliveryManager::finalize()
 {
   // clear the spike buffers
   for ( std::vector< std::vector< std::vector< std::vector< Target > > >* >::
-          iterator it = spike_register_5g_.begin();
-        it != spike_register_5g_.end();
+          iterator it = spike_register_.begin();
+        it != spike_register_.end();
         ++it )
   {
     delete ( *it );
   };
-  spike_register_5g_.clear();
+  spike_register_.clear();
 
   for (
     std::vector< std::vector< std::vector< std::vector< OffGridTarget > > >* >::
-      iterator it = off_grid_spike_register_5g_.begin();
-    it != off_grid_spike_register_5g_.end();
+      iterator it = off_grid_spike_register_.begin();
+    it != off_grid_spike_register_.end();
     ++it )
   {
     delete ( *it );
   };
-  off_grid_spike_register_5g_.clear();
+  off_grid_spike_register_.clear();
 }
 
 void
@@ -206,8 +206,8 @@ EventDeliveryManager::configure_spike_register()
 {
   for ( thread tid = 0; tid < kernel().vp_manager.get_num_threads(); ++tid )
   {
-    reset_spike_register_5g_( tid );
-    resize_spike_register_5g_( tid );
+    reset_spike_register_( tid );
+    resize_spike_register_( tid );
   }
 }
 
@@ -418,7 +418,7 @@ EventDeliveryManager::gather_spike_data_( const thread tid,
     me_completed_tid = collocate_spike_data_buffers_( tid,
       assigned_ranks,
       send_buffer_position,
-      spike_register_5g_,
+      spike_register_,
       send_buffer );
 
     if ( off_grid_spiking_ )
@@ -426,7 +426,7 @@ EventDeliveryManager::gather_spike_data_( const thread tid,
       me_completed_tid += collocate_spike_data_buffers_( tid,
         assigned_ranks,
         send_buffer_position,
-        off_grid_spike_register_5g_,
+        off_grid_spike_register_,
         send_buffer );
     }
     else
@@ -484,7 +484,7 @@ EventDeliveryManager::gather_spike_data_( const thread tid,
     } // of omp single; implicit barrier
 
     // deliver spikes from receive buffer to ring buffers
-    others_completed_tid = deliver_events_5g_( tid, recv_buffer );
+    others_completed_tid = deliver_events_( tid, recv_buffer );
 #pragma omp atomic
     completed_count += others_completed_tid;
 
@@ -516,7 +516,7 @@ EventDeliveryManager::gather_spike_data_( const thread tid,
 
   } // of while( true )
 
-  reset_spike_register_5g_( tid );
+  reset_spike_register_( tid );
 }
 
 template < typename TargetT, typename SpikeDataT >
@@ -644,11 +644,11 @@ EventDeliveryManager::set_complete_marker_spike_data_(
 
 template < typename SpikeDataT >
 bool
-EventDeliveryManager::deliver_events_5g_( const thread tid,
+EventDeliveryManager::deliver_events_( const thread tid,
   const std::vector< SpikeDataT >& recv_buffer )
 {
 #ifndef DISABLE_COUNTS
-  ++call_count_deliver_events_5g[ tid ];
+  ++call_count_deliver_events[ tid ];
 #endif
   const unsigned int send_recv_count_spike_data_per_rank =
     kernel().mpi_manager.get_send_recv_count_spike_data_per_rank();
@@ -701,7 +701,7 @@ EventDeliveryManager::deliver_events_5g_( const thread tid,
       {
         se.set_stamp( prepared_timestamps[ spike_data.get_lag() ] );
         se.set_offset( spike_data.get_offset() );
-        kernel().connection_manager.send_5g(
+        kernel().connection_manager.send(
           tid, spike_data.get_syn_id(), spike_data.get_lcid(), cm, se );
       }
 
@@ -999,11 +999,11 @@ nest::EventDeliveryManager::distribute_target_data_buffers_( const thread tid )
 }
 
 void
-EventDeliveryManager::resize_spike_register_5g_( const thread tid )
+EventDeliveryManager::resize_spike_register_( const thread tid )
 {
   for ( std::vector< std::vector< std::vector< Target > > >::iterator it =
-          ( *spike_register_5g_[ tid ] ).begin();
-        it != ( *spike_register_5g_[ tid ] ).end();
+          ( *spike_register_[ tid ] ).begin();
+        it != ( *spike_register_[ tid ] ).end();
         ++it )
   {
     it->resize(
@@ -1012,8 +1012,8 @@ EventDeliveryManager::resize_spike_register_5g_( const thread tid )
 
   for (
     std::vector< std::vector< std::vector< OffGridTarget > > >::iterator it =
-      ( *off_grid_spike_register_5g_[ tid ] ).begin();
-    it != ( *off_grid_spike_register_5g_[ tid ] ).end();
+      ( *off_grid_spike_register_[ tid ] ).begin();
+    it != ( *off_grid_spike_register_[ tid ] ).end();
     ++it )
   {
     it->resize( kernel().connection_manager.get_min_delay(),

--- a/nestkernel/event_delivery_manager.h
+++ b/nestkernel/event_delivery_manager.h
@@ -254,7 +254,7 @@ public:
   unsigned int comm_rounds_spike_data;
   unsigned int comm_steps_secondary_events;
 
-  std::vector< unsigned int > call_count_deliver_events_5g;
+  std::vector< unsigned int > call_count_deliver_events;
 
 private:
   template < typename SpikeDataT >
@@ -298,20 +298,20 @@ private:
    * nodes.
    */
   template < typename SpikeDataT >
-  bool deliver_events_5g_( const thread tid,
+  bool deliver_events_( const thread tid,
     const std::vector< SpikeDataT >& recv_buffer );
 
   /**
    * Deletes all spikes from spike registers and resets spike
    * counters.
    */
-  void reset_spike_register_5g_( const thread tid );
+  void reset_spike_register_( const thread tid );
 
   /**
    * Resizes spike registers according minimal delay so it can
    * accommodate all possible lags.
    */
-  void resize_spike_register_5g_( const thread tid );
+  void resize_spike_register_( const thread tid );
 
   /**
    * Returns true if spike has been moved to MPI buffer, such that it
@@ -396,7 +396,7 @@ private:
    * - Fourth dim: Target (will be converted in SpikeData)
    */
   std::vector< std::vector< std::vector< std::vector< Target > > >* >
-    spike_register_5g_;
+    spike_register_;
 
   /**
    * Register for gids of precise neurons that spiked. This is a 4-dim
@@ -409,7 +409,7 @@ private:
    * - Fourth dim: OffGridTarget (will be converted in OffGridSpikeData)
    */
   std::vector< std::vector< std::vector< std::vector< OffGridTarget > > >* >
-    off_grid_spike_register_5g_;
+    off_grid_spike_register_;
 
   /**
    * Buffer to collect the secondary events
@@ -461,11 +461,11 @@ private:
 };
 
 inline void
-EventDeliveryManager::reset_spike_register_5g_( const thread tid )
+EventDeliveryManager::reset_spike_register_( const thread tid )
 {
   for ( std::vector< std::vector< std::vector< Target > > >::iterator it =
-          ( *spike_register_5g_[ tid ] ).begin();
-        it < ( *spike_register_5g_[ tid ] ).end();
+          ( *spike_register_[ tid ] ).begin();
+        it < ( *spike_register_[ tid ] ).end();
         ++it )
   {
     for ( std::vector< std::vector< Target > >::iterator iit = ( *it ).begin();
@@ -478,8 +478,8 @@ EventDeliveryManager::reset_spike_register_5g_( const thread tid )
 
   for (
     std::vector< std::vector< std::vector< OffGridTarget > > >::iterator it =
-      ( *off_grid_spike_register_5g_[ tid ] ).begin();
-    it < ( *off_grid_spike_register_5g_[ tid ] ).end();
+      ( *off_grid_spike_register_[ tid ] ).begin();
+    it < ( *off_grid_spike_register_[ tid ] ).end();
     ++it )
   {
     for ( std::vector< std::vector< OffGridTarget > >::iterator iit =
@@ -502,8 +502,8 @@ inline void
 EventDeliveryManager::clean_spike_register_( const thread tid )
 {
   for ( std::vector< std::vector< std::vector< Target > > >::iterator it =
-          ( *spike_register_5g_[ tid ] ).begin();
-        it < ( *spike_register_5g_[ tid ] ).end();
+          ( *spike_register_[ tid ] ).begin();
+        it < ( *spike_register_[ tid ] ).end();
         ++it )
   {
     for ( std::vector< std::vector< Target > >::iterator iit = ( *it ).begin();
@@ -517,8 +517,8 @@ EventDeliveryManager::clean_spike_register_( const thread tid )
   }
   for (
     std::vector< std::vector< std::vector< OffGridTarget > > >::iterator it =
-      ( *off_grid_spike_register_5g_[ tid ] ).begin();
-    it < ( *off_grid_spike_register_5g_[ tid ] ).end();
+      ( *off_grid_spike_register_[ tid ] ).begin();
+    it < ( *off_grid_spike_register_[ tid ] ).end();
     ++it )
   {
     for ( std::vector< std::vector< OffGridTarget > >::iterator iit =

--- a/nestkernel/event_delivery_manager_impl.h
+++ b/nestkernel/event_delivery_manager_impl.h
@@ -110,7 +110,7 @@ EventDeliveryManager::send_remote( thread tid, SpikeEvent& e, const long lag )
       / kernel().vp_manager.get_num_assigned_ranks_per_thread();
     for ( int i = 0; i < e.get_multiplicity(); ++i )
     {
-      ( *spike_register_5g_[ tid ] )[ assigned_tid ][ lag ].push_back( *it );
+      ( *spike_register_[ tid ] )[ assigned_tid ][ lag ].push_back( *it );
     }
   }
 }
@@ -133,7 +133,7 @@ EventDeliveryManager::send_off_grid_remote( thread tid,
       / kernel().vp_manager.get_num_assigned_ranks_per_thread();
     for ( int i = 0; i < e.get_multiplicity(); ++i )
     {
-      ( *off_grid_spike_register_5g_[ tid ] )[ assigned_tid ][ lag ].push_back(
+      ( *off_grid_spike_register_[ tid ] )[ assigned_tid ][ lag ].push_back(
         OffGridTarget( *it, e.get_offset() ) );
     }
   }

--- a/nestkernel/simulation_manager.cpp
+++ b/nestkernel/simulation_manager.cpp
@@ -1099,11 +1099,11 @@ nest::SimulationManager::update_()
       std::cout << "0] CommStepsSecondaryEvents: "
                 << kernel().event_delivery_manager.comm_steps_secondary_events
                 << std::endl;
-      std::cout << "0] CallCount deliver_events_5g_: ";
+      std::cout << "0] CallCount deliver_events_: ";
       for ( thread tid = 0; tid < kernel().vp_manager.get_num_threads(); ++tid )
       {
         std::cout
-          << kernel().event_delivery_manager.call_count_deliver_events_5g[ tid ]
+          << kernel().event_delivery_manager.call_count_deliver_events[ tid ]
           << " ";
       }
       std::cout << std::endl;

--- a/nestkernel/sp_manager.cpp
+++ b/nestkernel/sp_manager.cpp
@@ -293,7 +293,7 @@ SPManager::disconnect( const index sgid,
   // normal nodes and devices with proxies
   if ( target->has_proxies() )
   {
-    kernel().connection_manager.disconnect_5g(
+    kernel().connection_manager.disconnect(
       target_thread, syn_id, sgid, target->get_gid() );
   }
   else if ( target->local_receiver() ) // normal devices
@@ -308,7 +308,7 @@ SPManager::disconnect( const index sgid,
       target_thread = source->get_thread();
       target = kernel().node_manager.get_node( target->get_gid(), sgid );
     }
-    kernel().connection_manager.disconnect_5g(
+    kernel().connection_manager.disconnect(
       target_thread, syn_id, sgid, target->get_gid() );
   }
   else // globally receiving devices iterate over all target threads
@@ -323,7 +323,7 @@ SPManager::disconnect( const index sgid,
     {
       target = kernel().node_manager.get_node( target->get_gid(), t );
       target_thread = target->get_thread();
-      kernel().connection_manager.disconnect_5g(
+      kernel().connection_manager.disconnect(
         target_thread, syn_id, sgid, target->get_gid() );
     }
   }
@@ -673,7 +673,7 @@ SPManager::delete_synapse( const index sgid,
     const thread target_thread = target->get_thread();
     if ( tid == target_thread )
     {
-      kernel().connection_manager.disconnect_5g( tid, syn_id, sgid, tgid );
+      kernel().connection_manager.disconnect( tid, syn_id, sgid, tgid );
 
       target->connect_synaptic_element( se_post_name, -1 );
     }

--- a/nestkernel/target_table.h
+++ b/nestkernel/target_table.h
@@ -93,7 +93,7 @@ public:
 
   /**
    * Returns all targets of a neuron. Used to fill
-   * EventDeliveryManager::spike_register_5g_.
+   * EventDeliveryManager::spike_register_.
    */
   const std::vector< Target >& get_targets( const thread tid,
     const index lid ) const;

--- a/nestkernel/target_table_devices_impl.h
+++ b/nestkernel/target_table_devices_impl.h
@@ -47,7 +47,7 @@ nest::TargetTableDevices::add_connection_to_device( Node& source,
 
   kernel()
     .model_manager.get_synapse_prototype( syn_id, tid )
-    .add_connection_5g(
+    .add_connection(
       source, target, &( *target_to_devices_[ tid ] )[ lid ], syn_id, p, d, w );
 }
 
@@ -67,7 +67,7 @@ nest::TargetTableDevices::add_connection_from_device( Node& source,
 
   kernel()
     .model_manager.get_synapse_prototype( syn_id, tid )
-    .add_connection_5g( source,
+    .add_connection( source,
       target,
       &( *target_from_devices_[ tid ] )[ ldid ],
       syn_id,


### PR DESCRIPTION
This PR removes all `_5g` suffixes that were used during the initial phase of the project