### PR TITLE
Move resize spike register 5g 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ pynest/pynestkernel.cpp
 *.pyc
 Makefile
 build/
+install/
 
 /juqueen/
 /extras/nest-config

--- a/nestkernel/event_delivery_manager.cpp
+++ b/nestkernel/event_delivery_manager.cpp
@@ -976,4 +976,27 @@ nest::EventDeliveryManager::distribute_target_data_buffers_( const thread tid )
   return are_others_completed;
 }
 
+void
+EventDeliveryManager::resize_spike_register_5g_( const thread tid )
+{
+  for ( std::vector< std::vector< std::vector< Target > > >::iterator it =
+          ( *spike_register_5g_[ tid ] ).begin();
+        it != ( *spike_register_5g_[ tid ] ).end();
+        ++it )
+  {
+    it->resize(
+      kernel().connection_manager.get_min_delay(), std::vector< Target >( 0 ) );
+  }
+
+  for (
+    std::vector< std::vector< std::vector< OffGridTarget > > >::iterator it =
+      ( *off_grid_spike_register_5g_[ tid ] ).begin();
+    it != ( *off_grid_spike_register_5g_[ tid ] ).end();
+    ++it )
+  {
+    it->resize( kernel().connection_manager.get_min_delay(),
+      std::vector< OffGridTarget >( 0 ) );
+  }
+}
+
 } // of namespace nest

--- a/nestkernel/event_delivery_manager_impl.h
+++ b/nestkernel/event_delivery_manager_impl.h
@@ -170,29 +170,6 @@ EventDeliveryManager::write_toggle() const
   return kernel().simulation_manager.get_slice() % 2;
 }
 
-inline void
-EventDeliveryManager::resize_spike_register_5g_( const thread tid )
-{
-  for ( std::vector< std::vector< std::vector< Target > > >::iterator it =
-          ( *spike_register_5g_[ tid ] ).begin();
-        it != ( *spike_register_5g_[ tid ] ).end();
-        ++it )
-  {
-    it->resize(
-      kernel().connection_manager.get_min_delay(), std::vector< Target >( 0 ) );
-  }
-
-  for (
-    std::vector< std::vector< std::vector< OffGridTarget > > >::iterator it =
-      ( *off_grid_spike_register_5g_[ tid ] ).begin();
-    it != ( *off_grid_spike_register_5g_[ tid ] ).end();
-    ++it )
-  {
-    it->resize( kernel().connection_manager.get_min_delay(),
-      std::vector< OffGridTarget >( 0 ) );
-  }
-}
-
 
 } // of namespace nest
 


### PR DESCRIPTION
This PR takes care of issue #44. The function resize_spike_register_5g_ is moved from event_delivery_manager_impl.h to event_delivery_manager.cpp.