### PR TITLE
Testsuite skipping C++ tests if compiled without Boost

### DIFF
--- a/nestkernel/connector_base.h
+++ b/nestkernel/connector_base.h
@@ -470,7 +470,7 @@ public:
   void
   sort_connections( std::vector< Source >& sources )
   {
-    sort( sources, C_ );
+    nest::sort( sources, C_ );
   }
 
   void // TODO@5g: -> has_subsequent_targets

--- a/testsuite/cpptests/test_sort.h
+++ b/testsuite/cpptests/test_sort.h
@@ -27,7 +27,6 @@
 #include <boost/test/unit_test.hpp>
 
 // C++ includes:
-#include <algorithm>
 #include <vector>
 
 // Includes from libnestutil:
@@ -65,7 +64,7 @@ BOOST_AUTO_TEST_CASE( test_random )
     vec1[ i ] = k;
   }
   
-  sort( vec0, vec1 );
+  nest::sort( vec0, vec1 );
 
   BOOST_REQUIRE( is_sorted( vec0.begin(), vec0.end() ) );
   BOOST_REQUIRE( is_sorted( vec1.begin(), vec1.end() ) );
@@ -83,7 +82,7 @@ BOOST_AUTO_TEST_CASE( test_linear )
     vec1[ i ] = N - i - 1;
   }
 
-  sort( vec0, vec1 );
+  nest::sort( vec0, vec1 );
 
   BOOST_REQUIRE( is_sorted( vec0.begin(), vec0.end() ) );
   BOOST_REQUIRE( is_sorted( vec1.begin(), vec1.end() ) );

--- a/testsuite/do_tests.sh.in
+++ b/testsuite/do_tests.sh.in
@@ -801,15 +801,19 @@ echo
 echo "Phase 8: Running C++ tests"
 echo "--------------------------"
 
-CPP_TEST_OUTPUT="$(run_all_cpptests 2>&1)"
-echo "$CPP_TEST_OUTPUT"
-CPP_TEST_TOTAL=$(echo "$CPP_TEST_OUTPUT" | sed -nr 's/.*Running ([0-9]+).*/\1/p')
-CPP_TEST_FAILED=$(echo "$CPP_TEST_OUTPUT" | sed -nr 's/.*([0-9]+) failure.*/\1/p')
-[ -z "$CPP_TEST_FAILED" ] && CPP_TEST_FAILED=0
-CPP_TEST_PASS=$(( $CPP_TEST_TOTAL - $CPP_TEST_FAILED ))
-TEST_TOTAL=$(( $TEST_TOTAL + $CPP_TEST_TOTAL ))
-TEST_PASSED=$(( $TEST_PASSED + $CPP_TEST_PASS ))
-TEST_FAILED=$(( $TEST_FAILED + $CPP_TEST_FAILED ))
+if type run_all_cpptests > /dev/null; then
+  CPP_TEST_OUTPUT="$(run_all_cpptests 2>&1)"
+  echo "$CPP_TEST_OUTPUT"
+  CPP_TEST_TOTAL=$(echo "$CPP_TEST_OUTPUT" | sed -nr 's/.*Running ([0-9]+).*/\1/p')
+  CPP_TEST_FAILED=$(echo "$CPP_TEST_OUTPUT" | sed -nr 's/.*([0-9]+) failure.*/\1/p')
+  [ -z "$CPP_TEST_FAILED" ] && CPP_TEST_FAILED=0
+  CPP_TEST_PASS=$(( $CPP_TEST_TOTAL - $CPP_TEST_FAILED ))
+  TEST_TOTAL=$(( $TEST_TOTAL + $CPP_TEST_TOTAL ))
+  TEST_PASSED=$(( $TEST_PASSED + $CPP_TEST_PASS ))
+  TEST_FAILED=$(( $TEST_FAILED + $CPP_TEST_FAILED ))
+else
+  echo "  Not running C++ tests because NEST was compiled without Boost."
+fi
 
 echo
 echo "NEST Testsuite Summary"


### PR DESCRIPTION
In making C++ tests work with the testsuite, I forgot about the scenario of not compiling with Boost (as pointed out in the PR). Sorry about that!

Also, the `sort` namespace has disappeared, making `sort()` ambiguous. So I added the `nest` namespace. But this can be changed if you have a solution you like better.