### PR TITLE
Add local_device_id to subnet

### DIFF
--- a/nestkernel/subnet.h
+++ b/nestkernel/subnet.h
@@ -82,10 +82,8 @@ public:
   void set_status( const DictionaryDatum& );
   void get_status( DictionaryDatum& ) const;
 
-  // subnet does not require local id; needs to be defined here to
-  // avoid exception in node_manager::add_node
-  void set_local_device_id( const index ldid ) {}
-  index get_local_device_id() const { return invalid_index; }
+  void set_local_device_id( const index ldid );
+  index get_local_device_id() const;
 
   bool has_proxies() const;
 
@@ -237,6 +235,8 @@ private:
   bool homogeneous_; //!< flag which indicates if the subnet contains different
                      //!< kinds of models.
   index last_mid_;   //!< model index of last child
+
+  index local_device_id_;
 };
 
 /**
@@ -383,6 +383,18 @@ inline bool
 Subnet::is_homogeneous() const
 {
   return homogeneous_;
+}
+
+inline void
+Subnet::set_local_device_id( const index ldid )
+{
+  local_device_id_ = ldid;
+}
+
+inline index
+Subnet::get_local_device_id() const
+{
+  return local_device_id_;
 }
 
 } // namespace


### PR DESCRIPTION
This fixes #53 and all test should now pass!

The problem is that `subnet` is looked upon as a device when we connect, so we use [`TargetTableDevices::add_connection_from_device(...)`](https://github.com/jakobj/nest-simulator/blob/5g/nestkernel/target_table_devices_impl.h#L55) when connecting, where the second line is 
```
assert( ldid != invalid_index );
```
and `subnet` has `local_device_id` set to `invalid_index`.

So I have now added a `local_device_id` to `subnet`.

Another solution @hakonsbm and I discussed, was to change the assertion in `add_connection_from_device()` to instead throw an exception, but as there is only a problem with `subnet`s, and as `subnet`s are to be removed with NEST3, we went with this solution, but I can change it if you want :)