### PR TITLE
Re-enable Travis failing on Vera errors

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -184,7 +184,7 @@ PERFORM_PEP8=true
 
 # The following command line parameters indicate whether static code analysis error messages
 # will cause the Travis CI build to fail or are ignored.
-IGNORE_MSG_VERA=true
+IGNORE_MSG_VERA=false
 IGNORE_MSG_CPPCHECK=true
 IGNORE_MSG_CLANG_FORMAT=false
 IGNORE_MSG_PEP8=false


### PR DESCRIPTION
When merging master, `IGNORE_MSG_VERA` was set to `true` again.