### PR TITLE
Update connection infrastructure in GetGonnections

### DIFF
--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -1193,6 +1193,21 @@ nest::ConnectionManager::get_connections(
     return;
   }
 
+  // if connections have changed, (re-)build presynaptic infrastructure,
+  // as this may involve sorting connections by source gids
+  if ( have_connections_changed() )
+  {
+    if ( not kernel().simulation_manager.has_been_simulated() )
+    {
+      kernel().model_manager.create_secondary_events_prototypes();
+    }
+#pragma omp parallel
+    {
+      const thread tid = kernel().vp_manager.get_thread_id();
+      kernel().simulation_manager.update_connection_infrastructure( tid );
+    }
+  }
+
   if ( source == 0 and target == 0 )
   {
 #pragma omp parallel

--- a/testsuite/unittests/test_connect_after_simulate.sli
+++ b/testsuite/unittests/test_connect_after_simulate.sli
@@ -21,14 +21,16 @@
  */
 
  /* BeginDocumentation
-   Name: testsuite::test_connect_after_simulate
+   Name: testsuite::test_connect_after_simulate - Create another connection after a call to Simulate and check whether it is created correctly
 
    Synopsis: (test_connect_after_simulate) run
 
-   Description:
-
-   Tests that it is possible to create connections between two
-   Simulate calls.
+   Description: 
+       Tests that it is possible to create connections between two
+       Simulate calls. 
+       Checks that the number of connections that GetConnection
+       returns and the number of detected spikes increases accordingly
+       when another connection is created.
 
    FirstVersion: 02/06/2016
    Author: Susanne Kunkel, Jakob Jordan
@@ -40,40 +42,87 @@ M_ERROR setverbosity
 (unittest) run
 /unittest using
 
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-% create second connection after a call to simulate and check whether
-% it is created correctly
+% Pre-condition:
+% Test that GetConnection returns the same connection handels before
+% and after calling Simulate for the case that connections are sorted
+% by source and for the case that they are not sorted
+[ true false ]
+{
+  /sort_connections Set
 
-ResetKernel
+  ResetKernel
 
-/neuron /iaf_psc_delta << /I_e 500. >> Create def
-/parrot /parrot_neuron Create def
-/dummys /iaf_psc_delta 10 Create def
-/detector /spike_detector Create def
+  /neurons [ 1 /iaf_psc_alpha 10 Create ] Range cvgidcollection def
 
-[neuron] [parrot] Connect
-[3 dummys] Range cvgidcollection [3 dummys] Range cvgidcollection Connect
-[parrot] [detector] Connect
+  0 << /sort_connections_by_source sort_connections >> SetStatus
+  neurons neurons << /rule /fixed_indegree /indegree 2 >> << >> Connect
 
-20 Simulate
+  /connections_before << >> GetConnections def
+  1.0 Simulate
+  /connections_after << >> GetConnections def
+  connections_before connections_after eq assert_or_die
 
-<< /target [parrot] >> GetConnections size 1 eq assert_or_die
-<< /target [parrot] >> GetConnections 0 get cva 4 get 0 eq assert_or_die
-detector GetStatus /n_events get 1 eq assert_or_die
+  % switch from sort to no-sort or vice versa
+  % and create more connections and check again
+  0 << /sort_connections_by_source sort_connections not >> SetStatus
+  neurons neurons << /rule /fixed_indegree /indegree 2 >> << >> Connect
 
-[neuron] [parrot] Connect
+  /connections_before << >> GetConnections def
+  1.0 Simulate
+  /connections_after << >> GetConnections def
+  connections_before connections_after eq assert_or_die
+}
+forall
 
-<< /target [parrot] >> GetConnections size 2 eq assert_or_die
-<< /target [parrot] >> GetConnections 0 get cva 4 get 0 eq assert_or_die
-% before call to simulate connections are not sorted by source, so
-% port of second connection should be 101
-<< /target [parrot] >> GetConnections 1 get cva 4 get 101 eq assert_or_die
+% Now, the actual test for the sort and no-sort case
+[ true false ]
+{
+  /sort_connections Set
 
-20 Simulate
+  ResetKernel
 
-<< /target [parrot] >> GetConnections size 2 eq assert_or_die
-<< /target [parrot] >> GetConnections 0 get cva 4 get 0 eq assert_or_die
-% after call to simulate connections should be sorted, so port of
-% second connection should be 1
-<< /target [parrot] >> GetConnections 1 get cva 4 get 1 eq assert_or_die
-detector GetStatus /n_events get 3 eq assert_or_die
+  0 << /sort_connections_by_source sort_connections >> SetStatus
+
+  /neuron /iaf_psc_delta << /I_e 500. >> Create def
+  /parrot /parrot_neuron Create def
+  /dummies [ parrot 1 add /iaf_psc_delta 10 Create ] Range cvgidcollection def
+  /detector /spike_detector Create def
+
+  [neuron] [parrot] Connect
+  dummies dummies << /rule /all_to_all >> << >> Connect
+  [parrot] [detector] Connect
+
+  20 Simulate
+
+  << /target [parrot] >> GetConnections size 1 eq assert_or_die
+  << /target [parrot] >> GetConnections 0 get cva 4 get 0 eq assert_or_die
+  detector GetStatus /n_events get 1 eq assert_or_die
+
+  [neuron] [parrot] Connect
+
+  << /target [parrot] >> GetConnections size 2 eq assert_or_die
+  << /target [parrot] >> GetConnections 0 get cva 4 get 0 eq assert_or_die
+  sort_connections
+  {
+    << /target [parrot] >> GetConnections 1 get cva 4 get 1 eq assert_or_die
+  }
+  {
+    << /target [parrot] >> GetConnections 1 get cva 4 get 101 eq assert_or_die
+  }
+  ifelse
+  
+  20 Simulate
+
+  << /target [parrot] >> GetConnections size 2 eq assert_or_die
+  << /target [parrot] >> GetConnections 0 get cva 4 get 0 eq assert_or_die
+  sort_connections
+  {
+    << /target [parrot] >> GetConnections 1 get cva 4 get 1 eq assert_or_die
+  }
+  {
+    << /target [parrot] >> GetConnections 1 get cva 4 get 101 eq assert_or_die
+  }
+  ifelse
+  detector GetStatus /n_events get 3 eq assert_or_die
+}
+forall

--- a/topology/testsuite/unittests/test_free_mask_circ_anchor_00.sli
+++ b/topology/testsuite/unittests/test_free_mask_circ_anchor_00.sli
@@ -243,7 +243,7 @@ def
 
 ResetKernel
 
-
+0 << /sort_connections_by_source false >> SetStatus
 
 /sources src_layer CreateLayer def
 /targets tgt_layer CreateLayer def

--- a/topology/testsuite/unittests/test_free_mask_circ_anchor_01.sli
+++ b/topology/testsuite/unittests/test_free_mask_circ_anchor_01.sli
@@ -232,7 +232,7 @@ def
 
 ResetKernel
 
-
+0 << /sort_connections_by_source false >> SetStatus
 
 /sources src_layer CreateLayer def
 /targets tgt_layer CreateLayer def

--- a/topology/testsuite/unittests/test_free_mask_circ_anchor_10.sli
+++ b/topology/testsuite/unittests/test_free_mask_circ_anchor_10.sli
@@ -266,7 +266,7 @@ def
 
 ResetKernel
 
-
+0 << /sort_connections_by_source false >> SetStatus
 
 /sources src_layer CreateLayer def
 /targets tgt_layer CreateLayer def

--- a/topology/testsuite/unittests/test_free_mask_circ_anchor_11.sli
+++ b/topology/testsuite/unittests/test_free_mask_circ_anchor_11.sli
@@ -266,7 +266,7 @@ def
 
 ResetKernel
 
-
+0 << /sort_connections_by_source false >> SetStatus
 
 /sources src_layer CreateLayer def
 /targets tgt_layer CreateLayer def

--- a/topology/testsuite/unittests/test_free_mask_donut_anchor_00.sli
+++ b/topology/testsuite/unittests/test_free_mask_donut_anchor_00.sli
@@ -217,7 +217,7 @@ def
 
 ResetKernel
 
-
+0 << /sort_connections_by_source false >> SetStatus
 
 /sources src_layer CreateLayer def
 /targets tgt_layer CreateLayer def

--- a/topology/testsuite/unittests/test_free_mask_donut_anchor_01.sli
+++ b/topology/testsuite/unittests/test_free_mask_donut_anchor_01.sli
@@ -212,7 +212,7 @@ def
 
 ResetKernel
 
-
+0 << /sort_connections_by_source false >> SetStatus
 
 /sources src_layer CreateLayer def
 /targets tgt_layer CreateLayer def

--- a/topology/testsuite/unittests/test_free_mask_donut_anchor_10.sli
+++ b/topology/testsuite/unittests/test_free_mask_donut_anchor_10.sli
@@ -240,7 +240,7 @@ def
 
 ResetKernel
 
-
+0 << /sort_connections_by_source false >> SetStatus
 
 /sources src_layer CreateLayer def
 /targets tgt_layer CreateLayer def

--- a/topology/testsuite/unittests/test_free_mask_donut_anchor_11.sli
+++ b/topology/testsuite/unittests/test_free_mask_donut_anchor_11.sli
@@ -242,7 +242,7 @@ def
 
 ResetKernel
 
-
+0 << /sort_connections_by_source false >> SetStatus
 
 /sources src_layer CreateLayer def
 /targets tgt_layer CreateLayer def

--- a/topology/testsuite/unittests/test_free_mask_rect_00.sli
+++ b/topology/testsuite/unittests/test_free_mask_rect_00.sli
@@ -245,7 +245,7 @@ def
 
 ResetKernel
 
-
+0 << /sort_connections_by_source false >> SetStatus
 
 /sources src_layer CreateLayer def
 /targets tgt_layer CreateLayer def

--- a/topology/testsuite/unittests/test_free_mask_rect_01.sli
+++ b/topology/testsuite/unittests/test_free_mask_rect_01.sli
@@ -227,7 +227,7 @@ def
 
 ResetKernel
 
-
+0 << /sort_connections_by_source false >> SetStatus
 
 /sources src_layer CreateLayer def
 /targets tgt_layer CreateLayer def

--- a/topology/testsuite/unittests/test_free_mask_rect_11.sli
+++ b/topology/testsuite/unittests/test_free_mask_rect_11.sli
@@ -270,7 +270,7 @@ def
 
 ResetKernel
 
-
+0 << /sort_connections_by_source false >> SetStatus
 
 /sources src_layer CreateLayer def
 /targets tgt_layer CreateLayer def

--- a/topology/testsuite/unittests/test_free_mask_rect_13.sli
+++ b/topology/testsuite/unittests/test_free_mask_rect_13.sli
@@ -356,7 +356,7 @@ def
 
 ResetKernel
 
-
+0 << /sort_connections_by_source false >> SetStatus
 
 /sources src_layer CreateLayer def
 /targets tgt_layer CreateLayer def

--- a/topology/testsuite/unittests/test_reg_mask_circ_anchor_00.sli
+++ b/topology/testsuite/unittests/test_reg_mask_circ_anchor_00.sli
@@ -235,7 +235,7 @@ def
 
 ResetKernel
 
-
+0 << /sort_connections_by_source false >> SetStatus
 
 /sources src_layer CreateLayer def
 /targets tgt_layer CreateLayer def

--- a/topology/testsuite/unittests/test_reg_mask_circ_anchor_01.sli
+++ b/topology/testsuite/unittests/test_reg_mask_circ_anchor_01.sli
@@ -224,7 +224,7 @@ def
 
 ResetKernel
 
-
+0 << /sort_connections_by_source false >> SetStatus
 
 /sources src_layer CreateLayer def
 /targets tgt_layer CreateLayer def

--- a/topology/testsuite/unittests/test_reg_mask_circ_anchor_10.sli
+++ b/topology/testsuite/unittests/test_reg_mask_circ_anchor_10.sli
@@ -258,7 +258,7 @@ def
 
 ResetKernel
 
-
+0 << /sort_connections_by_source false >> SetStatus
 
 /sources src_layer CreateLayer def
 /targets tgt_layer CreateLayer def

--- a/topology/testsuite/unittests/test_reg_mask_circ_anchor_11.sli
+++ b/topology/testsuite/unittests/test_reg_mask_circ_anchor_11.sli
@@ -259,7 +259,7 @@ def
 
 ResetKernel
 
-
+0 << /sort_connections_by_source false >> SetStatus
 
 /sources src_layer CreateLayer def
 /targets tgt_layer CreateLayer def

--- a/topology/testsuite/unittests/test_reg_mask_donut_anchor_00.sli
+++ b/topology/testsuite/unittests/test_reg_mask_donut_anchor_00.sli
@@ -209,7 +209,7 @@ def
 
 ResetKernel
 
-
+0 << /sort_connections_by_source false >> SetStatus
 
 /sources src_layer CreateLayer def
 /targets tgt_layer CreateLayer def

--- a/topology/testsuite/unittests/test_reg_mask_donut_anchor_01.sli
+++ b/topology/testsuite/unittests/test_reg_mask_donut_anchor_01.sli
@@ -204,7 +204,7 @@ def
 
 ResetKernel
 
-
+0 << /sort_connections_by_source false >> SetStatus
 
 /sources src_layer CreateLayer def
 /targets tgt_layer CreateLayer def

--- a/topology/testsuite/unittests/test_reg_mask_donut_anchor_10.sli
+++ b/topology/testsuite/unittests/test_reg_mask_donut_anchor_10.sli
@@ -232,7 +232,7 @@ def
 
 ResetKernel
 
-
+0 << /sort_connections_by_source false >> SetStatus
 
 /sources src_layer CreateLayer def
 /targets tgt_layer CreateLayer def

--- a/topology/testsuite/unittests/test_reg_mask_donut_anchor_11.sli
+++ b/topology/testsuite/unittests/test_reg_mask_donut_anchor_11.sli
@@ -234,7 +234,7 @@ def
 
 ResetKernel
 
-
+0 << /sort_connections_by_source false >> SetStatus
 
 /sources src_layer CreateLayer def
 /targets tgt_layer CreateLayer def

--- a/topology/testsuite/unittests/test_reg_mask_grid_anchor_00.sli
+++ b/topology/testsuite/unittests/test_reg_mask_grid_anchor_00.sli
@@ -236,7 +236,7 @@ def
 
 ResetKernel
 
-
+0 << /sort_connections_by_source false >> SetStatus
 
 /sources src_layer CreateLayer def
 /targets tgt_layer CreateLayer def

--- a/topology/testsuite/unittests/test_reg_mask_grid_anchor_01.sli
+++ b/topology/testsuite/unittests/test_reg_mask_grid_anchor_01.sli
@@ -237,7 +237,7 @@ def
 
 ResetKernel
 
-
+0 << /sort_connections_by_source false >> SetStatus
 
 /sources src_layer CreateLayer def
 /targets tgt_layer CreateLayer def

--- a/topology/testsuite/unittests/test_reg_mask_grid_anchor_02.sli
+++ b/topology/testsuite/unittests/test_reg_mask_grid_anchor_02.sli
@@ -209,7 +209,7 @@ def
 
 ResetKernel
 
-
+0 << /sort_connections_by_source false >> SetStatus
 
 /sources src_layer CreateLayer def
 /targets tgt_layer CreateLayer def

--- a/topology/testsuite/unittests/test_reg_mask_grid_anchor_03.sli
+++ b/topology/testsuite/unittests/test_reg_mask_grid_anchor_03.sli
@@ -240,7 +240,7 @@ def
 
 ResetKernel
 
-
+0 << /sort_connections_by_source false >> SetStatus
 
 /sources src_layer CreateLayer def
 /targets tgt_layer CreateLayer def

--- a/topology/testsuite/unittests/test_reg_mask_grid_anchor_04.sli
+++ b/topology/testsuite/unittests/test_reg_mask_grid_anchor_04.sli
@@ -203,7 +203,7 @@ def
 
 ResetKernel
 
-
+0 << /sort_connections_by_source false >> SetStatus
 
 /sources src_layer CreateLayer def
 /targets tgt_layer CreateLayer def

--- a/topology/testsuite/unittests/test_reg_mask_grid_anchor_05.sli
+++ b/topology/testsuite/unittests/test_reg_mask_grid_anchor_05.sli
@@ -130,7 +130,7 @@ def
 
 ResetKernel
 
-
+0 << /sort_connections_by_source false >> SetStatus
 
 /sources src_layer CreateLayer def
 /targets tgt_layer CreateLayer def

--- a/topology/testsuite/unittests/test_reg_mask_grid_anchor_06.sli
+++ b/topology/testsuite/unittests/test_reg_mask_grid_anchor_06.sli
@@ -294,7 +294,7 @@ def
 
 ResetKernel
 
-
+0 << /sort_connections_by_source false >> SetStatus
 
 /sources src_layer CreateLayer def
 /targets tgt_layer CreateLayer def

--- a/topology/testsuite/unittests/test_reg_mask_grid_anchor_10.sli
+++ b/topology/testsuite/unittests/test_reg_mask_grid_anchor_10.sli
@@ -272,7 +272,7 @@ def
 
 ResetKernel
 
-
+0 << /sort_connections_by_source false >> SetStatus
 
 /sources src_layer CreateLayer def
 /targets tgt_layer CreateLayer def

--- a/topology/testsuite/unittests/test_reg_mask_grid_anchor_11.sli
+++ b/topology/testsuite/unittests/test_reg_mask_grid_anchor_11.sli
@@ -272,7 +272,7 @@ def
 
 ResetKernel
 
-
+0 << /sort_connections_by_source false >> SetStatus
 
 /sources src_layer CreateLayer def
 /targets tgt_layer CreateLayer def

--- a/topology/testsuite/unittests/test_reg_mask_grid_anchor_13.sli
+++ b/topology/testsuite/unittests/test_reg_mask_grid_anchor_13.sli
@@ -272,7 +272,7 @@ def
 
 ResetKernel
 
-
+0 << /sort_connections_by_source false >> SetStatus
 
 /sources src_layer CreateLayer def
 /targets tgt_layer CreateLayer def

--- a/topology/testsuite/unittests/test_reg_mask_grid_anchor_15.sli
+++ b/topology/testsuite/unittests/test_reg_mask_grid_anchor_15.sli
@@ -287,7 +287,7 @@ def
 
 ResetKernel
 
-
+0 << /sort_connections_by_source false >> SetStatus
 
 /sources src_layer CreateLayer def
 /targets tgt_layer CreateLayer def

--- a/topology/testsuite/unittests/test_reg_mask_rect_00.sli
+++ b/topology/testsuite/unittests/test_reg_mask_rect_00.sli
@@ -239,7 +239,7 @@ def
 
 ResetKernel
 
-
+0 << /sort_connections_by_source false >> SetStatus
 
 /sources src_layer CreateLayer def
 /targets tgt_layer CreateLayer def

--- a/topology/testsuite/unittests/test_reg_mask_rect_01.sli
+++ b/topology/testsuite/unittests/test_reg_mask_rect_01.sli
@@ -242,7 +242,7 @@ def
 
 ResetKernel
 
-
+0 << /sort_connections_by_source false >> SetStatus
 
 /sources src_layer CreateLayer def
 /targets tgt_layer CreateLayer def

--- a/topology/testsuite/unittests/test_reg_mask_rect_02.sli
+++ b/topology/testsuite/unittests/test_reg_mask_rect_02.sli
@@ -237,7 +237,7 @@ def
 
 ResetKernel
 
-
+0 << /sort_connections_by_source false >> SetStatus
 
 /sources src_layer CreateLayer def
 /targets tgt_layer CreateLayer def

--- a/topology/testsuite/unittests/test_reg_mask_rect_10.sli
+++ b/topology/testsuite/unittests/test_reg_mask_rect_10.sli
@@ -281,6 +281,7 @@ def
 ResetKernel
 
 
+0 << /sort_connections_by_source false >> SetStatus
 
 /sources src_layer CreateLayer def
 /targets tgt_layer CreateLayer def

--- a/topology/testsuite/unittests/test_reg_mask_rect_11.sli
+++ b/topology/testsuite/unittests/test_reg_mask_rect_11.sli
@@ -283,7 +283,7 @@ def
 
 ResetKernel
 
-
+0 << /sort_connections_by_source false >> SetStatus
 
 /sources src_layer CreateLayer def
 /targets tgt_layer CreateLayer def

--- a/topology/testsuite/unittests/test_weight_delay.sli
+++ b/topology/testsuite/unittests/test_weight_delay.sli
@@ -190,6 +190,8 @@ def
 
 ResetKernel
 
+0 << /sort_connections_by_source false >> SetStatus
+
 userdict /resolution known { 0 << /resolution resolution >> SetStatus } if
 
 /sources src_layer CreateLayer def

--- a/topology/testsuite/unittests/test_weight_delay_free.sli
+++ b/topology/testsuite/unittests/test_weight_delay_free.sli
@@ -192,6 +192,8 @@ def
 
 ResetKernel
 
+0 << /sort_connections_by_source false >> SetStatus
+
 userdict /resolution known { 0 << /resolution resolution >> SetStatus } if
 
 /sources src_layer CreateLayer def


### PR DESCRIPTION
This PR should prevent that `GetConnections` returns different connection handles when it is called before `Simulate` compared to when it is called after `Simulate`, see issue #28