### PR TITLE
Do not sort connection in structural plasticity update

### DIFF
--- a/nestkernel/sp_manager.cpp
+++ b/nestkernel/sp_manager.cpp
@@ -838,7 +838,6 @@ void
 nest::SPManager::global_shuffle( std::vector< index >& v, size_t n )
 {
   assert( n <= v.size() );
-  std::sort( v.begin(), v.end() ); // TODO@5g: remove
 
   // shuffle res using the global random number generator
   unsigned int N = v.size();


### PR DESCRIPTION
We had introduced sorting to be able to compare master and 5g. This PR removes this sorting again. Exact results will differ to the master branch, but still be statistically identical.