### PR TITLE
Fix/gather

### DIFF
--- a/nestkernel/CMakeLists.txt
+++ b/nestkernel/CMakeLists.txt
@@ -22,6 +22,7 @@ set( nestkernel_sources
     recordables_map.h
     archiving_node.h archiving_node.cpp
     common_synapse_properties.h common_synapse_properties.cpp
+    completed_checker.h completed_checker.cpp
     sibling_container.h sibling_container.cpp
     subnet.h subnet.cpp
     connection.h

--- a/nestkernel/completed_checker.cpp
+++ b/nestkernel/completed_checker.cpp
@@ -1,0 +1,92 @@
+/*
+ *  completed_checker.cpp
+ *
+ *  This file is part of NEST.
+ *
+ *  Copyright (C) 2004 The NEST Initiative
+ *
+ *  NEST is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  NEST is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "completed_checker.h"
+
+namespace nest
+{
+
+CompletedChecker::CompletedChecker()
+    : a_( NULL )
+  , size_( 0 )
+{
+}
+
+CompletedChecker::~CompletedChecker()
+{
+  clear();
+}
+
+bool
+CompletedChecker::all_false() const
+{
+#pragma omp barrier
+  for ( size_t i = 0; i < size_; ++i )
+  {
+    if ( a_[ i ] )
+    {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool
+CompletedChecker::all_true() const
+{
+#pragma omp barrier
+  for ( size_t i = 0; i < size_; ++i )
+  {
+    if ( not a_[ i ] )
+    {
+      return false;
+    }
+  }
+  return true;
+}
+
+void
+CompletedChecker::clear()
+{
+  VPManager::assert_single_threaded();
+  if ( a_ != NULL )
+  {
+    delete a_;
+    a_ = NULL;
+    size_ = 0;
+  }
+}
+
+void
+CompletedChecker::resize( const size_t new_size, const bool v )
+{
+  VPManager::assert_single_threaded();
+  clear();
+  a_ = new bool[ new_size ];
+  for ( size_t i = 0; i < new_size; ++i )
+  {
+    a_[ i ] = v;
+  }
+  size_ = new_size;
+}
+
+} /* namespace nest */

--- a/nestkernel/completed_checker.h
+++ b/nestkernel/completed_checker.h
@@ -1,0 +1,129 @@
+/*
+ *  completed_checker.h
+ *
+ *  This file is part of NEST.
+ *
+ *  Copyright (C) 2004 The NEST Initiative
+ *
+ *  NEST is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  NEST is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef COMPLETED_CHECKER_H
+#define COMPLETED_CHECKER_H
+
+// C++ includes:
+#include <cassert>
+#include <cstddef>
+
+// Includes from nestkernel:
+#include "nest_types.h"
+#include "vp_manager.h"
+
+// Includes from sli:
+#include "dictdatum.h"
+
+namespace nest
+{
+
+/**
+ * A thread-safe array to coordinate progress across threads during
+ * gather operations. Uses an array of bools instead of an STL vector,
+ * since omp atomic operations can not be applied to vector
+ * assignments.
+ */
+
+class CompletedChecker
+{
+private:
+
+  /**
+   * Array holding status values for all threads. must be of type
+   * bool; 'bitwise and' is used below instead of 'logical and'.
+   */
+  bool* a_;
+
+  /**
+   * Size of a. should always be identical to number of threads.
+   */
+  size_t size_;
+
+public:
+  CompletedChecker();
+
+  ~CompletedChecker();
+
+  /**
+   *  Returns whether all elements are false. Waits for all threads.
+   */
+  bool all_false() const;
+
+  /**
+   * Returns whether all elements are true. Waits for all threads.
+   */
+  bool all_true() const;
+
+  /**
+   * Clears array and sets size to zero.
+   */
+  void clear();
+
+  /**
+   * Updates element for thread tid by computing its 'logical and'
+   * with given value.
+   */
+  void logical_and( const thread tid, const bool v );
+
+  /**
+   * Resizes array to given size.
+   */
+  void resize( const size_t new_size, const bool v );
+
+  /**
+   * Sets element for thread tid to given value.
+   */
+  void set( const thread tid, const bool v );
+
+  /**
+   * Returns const reference toelement at position tid.
+   */
+  const bool& operator[]( const thread tid ) const;
+
+};
+
+inline void
+CompletedChecker::logical_and( const thread tid, const bool v )
+{
+  // use 'bitwise and', since 'logical and' is not supported by 'omp
+  // atomic update'; yields same result for bool
+#pragma omp atomic update
+  a_[ tid ] &= v;
+}
+
+inline void
+CompletedChecker::set( const thread tid, const bool v )
+{
+#pragma omp atomic write
+  a_[ tid ] = v;
+}
+
+inline const bool&
+CompletedChecker::operator[]( const thread tid ) const
+{
+  return a_[ tid ];
+}
+
+} // namespace nest
+
+#endif /* COMPLETED_CHECKER_H */

--- a/nestkernel/event_delivery_manager.cpp
+++ b/nestkernel/event_delivery_manager.cpp
@@ -309,12 +309,8 @@ EventDeliveryManager::reset_timers_counters()
 }
 
 void
-EventDeliveryManager::gather_secondary_events( const bool done )
+EventDeliveryManager::write_done_marker_secondary_events_( const bool done )
 {
-#ifndef DISABLE_COUNTS
-  ++comm_steps_secondary_events;
-#endif
-
   // write done marker at last position in every chunk
   const size_t chunk_size_in_int =
     kernel().mpi_manager.get_chunk_size_secondary_events_in_int();
@@ -324,6 +320,16 @@ EventDeliveryManager::gather_secondary_events( const bool done )
     send_buffer_secondary_events_[ ( rank + 1 ) * chunk_size_in_int - 1 ] =
       done;
   }
+}
+
+void
+EventDeliveryManager::gather_secondary_events( const bool done )
+{
+#ifndef DISABLE_COUNTS
+  ++comm_steps_secondary_events;
+#endif
+
+  write_done_marker_secondary_events_( done );
 
 #ifndef DISABLE_TIMING
   kernel().mpi_manager.synchronize(); // to get an accurate time measurement

--- a/nestkernel/event_delivery_manager.cpp
+++ b/nestkernel/event_delivery_manager.cpp
@@ -58,7 +58,7 @@ EventDeliveryManager::EventDeliveryManager()
   , recv_buffer_target_data_()
   , buffer_size_target_data_has_changed_( false )
   , buffer_size_spike_data_has_changed_( false )
-  , completed_count_( std::vector< unsigned int >() )
+  , gather_completed_checker_( CompletedChecker() )
 {
 #ifndef DISABLE_COUNTS
   comm_steps_target_data = 0;
@@ -84,7 +84,7 @@ EventDeliveryManager::initialize()
   reset_timers_counters();
   spike_register_.resize( num_threads, NULL );
   off_grid_spike_register_.resize( num_threads, NULL );
-  completed_count_.resize( num_threads, 0 );
+  gather_completed_checker_.resize( num_threads, false );
 #ifndef DISABLE_COUNTS
   call_count_deliver_events.resize( num_threads, 0 );
 #endif
@@ -138,6 +138,8 @@ EventDeliveryManager::finalize()
     delete ( *it );
   };
   off_grid_spike_register_.clear();
+
+  gather_completed_checker_.clear();
 }
 
 void
@@ -365,7 +367,6 @@ EventDeliveryManager::gather_spike_data( const thread tid )
   }
 }
 
-// TODO@5g: make pretty and use reasonable variable names -> Jakob
 template < typename SpikeDataT >
 void
 EventDeliveryManager::gather_spike_data_( const thread tid,
@@ -379,28 +380,22 @@ EventDeliveryManager::gather_spike_data_( const thread tid,
   }
 #endif
 
-  // counters to keep track of threads and ranks that have send out
-  // all spikes
-  static unsigned int
-    completed_count; // needs to be static to be visible across threads
-  const unsigned int half_completed_count = 2
-    * kernel()
-        .vp_manager.get_num_threads(); // count for on grid and off grid spikes
-  const unsigned int max_completed_count =
-    half_completed_count + kernel().vp_manager.get_num_threads();
-  unsigned int me_completed_tid = 0;
-  unsigned int others_completed_tid = 0;
+  // assume all threads have some work to do
+  gather_completed_checker_.set( tid,  false );
+  assert( gather_completed_checker_.all_false() );
 
   const AssignedRanks assigned_ranks =
     kernel().vp_manager.get_assigned_ranks( tid );
 
-  // can not use while(true) and break in an omp structured block
-  bool done = false;
-  while ( not done )
+  while ( not gather_completed_checker_.all_true() )
   {
+
+    // assume this is the last gather round and change to false
+    // otherwise
+    gather_completed_checker_.set( tid, true );
+
 #pragma omp single
     {
-      completed_count = 0;
       if ( kernel().mpi_manager.adaptive_spike_buffers()
         and buffer_size_spike_data_has_changed_ )
       {
@@ -421,20 +416,18 @@ EventDeliveryManager::gather_spike_data_( const thread tid,
       kernel().mpi_manager.get_send_recv_count_spike_data_per_rank() );
 
     // collocate spikes to send buffer
-    me_completed_tid = collocate_spike_data_buffers_(
+    const bool collocate_completed = collocate_spike_data_buffers_(
       tid, assigned_ranks, send_buffer_position, spike_register_, send_buffer );
+    gather_completed_checker_.logical_and( tid, collocate_completed );
 
     if ( off_grid_spiking_ )
     {
-      me_completed_tid += collocate_spike_data_buffers_( tid,
+      const bool collocate_completed_off_grid = collocate_spike_data_buffers_( tid,
         assigned_ranks,
         send_buffer_position,
         off_grid_spike_register_,
         send_buffer );
-    }
-    else
-    {
-      ++me_completed_tid;
+      gather_completed_checker_.logical_and( tid, collocate_completed_off_grid );
     }
 
 // set markers to signal end of valid spikes, and remove spikes
@@ -444,13 +437,9 @@ EventDeliveryManager::gather_spike_data_( const thread tid,
       assigned_ranks, send_buffer_position, send_buffer );
     clean_spike_register_( tid );
 
-#pragma omp atomic
-    completed_count += me_completed_tid;
-#pragma omp barrier
-
     // if we do not have any spikes left, set corresponding marker in
     // send buffer
-    if ( completed_count == half_completed_count )
+    if ( gather_completed_checker_.all_true() )
     {
       // needs to be called /after/ set_end_and_invalid_markers_
       set_complete_marker_spike_data_(
@@ -487,12 +476,11 @@ EventDeliveryManager::gather_spike_data_( const thread tid,
     } // of omp single; implicit barrier
 
     // deliver spikes from receive buffer to ring buffers
-    others_completed_tid = deliver_events_( tid, recv_buffer );
-#pragma omp atomic
-    completed_count += others_completed_tid;
+    const bool deliver_completed = deliver_events_( tid, recv_buffer );
+    gather_completed_checker_.logical_and( tid, deliver_completed );
 
-// exit gather loop if all local threads and remote processes are
-// done
+    // exit gather loop if all local threads and remote processes are
+    // done
 #pragma omp barrier
 
 #ifndef DISABLE_TIMING
@@ -502,12 +490,9 @@ EventDeliveryManager::gather_spike_data_( const thread tid,
     }
 #endif
 
-    if ( completed_count == max_completed_count )
-    {
-      done = true;
-    }
-    // otherwise, resize mpi buffers, if allowed
-    else if ( kernel().mpi_manager.adaptive_spike_buffers() )
+    // resize mpi buffers, if necessary and allowed
+    if ( not gather_completed_checker_.all_true()
+         and kernel().mpi_manager.adaptive_spike_buffers() )
     {
 #pragma omp single
       {
@@ -517,7 +502,7 @@ EventDeliveryManager::gather_spike_data_( const thread tid,
     }
 #pragma omp barrier
 
-  } // of while( true )
+  } // of while
 
   reset_spike_register_( tid );
 }
@@ -738,6 +723,10 @@ EventDeliveryManager::gather_target_data( const thread tid )
 {
   assert( not kernel().connection_manager.is_source_table_cleared() );
 
+  // assume all threads have some work to do
+  gather_completed_checker_.set( tid, false );
+  assert( gather_completed_checker_.all_false() );
+
 #ifndef DISABLE_COUNTS
   if ( tid == 0 and kernel().mpi_manager.get_rank() < 30 )
   {
@@ -745,31 +734,19 @@ EventDeliveryManager::gather_target_data( const thread tid )
   }
 #endif
 
-  // when a thread does not have any more spike to collocate and when
-  // it detects a remote MPI rank is finished this count is increased
-  // by 1 in each case. only if all threads are done AND all threads
-  // detect all remote ranks are done, we are allowed to stop
-  // communication.
-  unsigned int completed_count; // TODO@5g: use same strategy in
-  // gather_spike data? could use same
-  // completed_count_ vector -> Susi
-  const unsigned int half_completed_count =
-    kernel().vp_manager.get_num_threads();
-  const unsigned int max_completed_count = 2 * half_completed_count;
-
-  bool me_completed_tid;
-  bool others_completed_tid;
   const AssignedRanks assigned_ranks =
     kernel().vp_manager.get_assigned_ranks( tid );
 
   kernel().connection_manager.prepare_target_table( tid );
   kernel().connection_manager.reset_source_table_entry_point( tid );
 
-  // can not use while(true) and break in an omp structured block
-  bool done = false;
-  while ( not done )
+  while ( not gather_completed_checker_.all_true() )
   {
-    completed_count_[ tid ] = 0;
+
+    // assume this is the last gather round and change to false
+    // otherwise
+    gather_completed_checker_.set( tid, true );
+
 #pragma omp single
     {
       if ( kernel().mpi_manager.adaptive_target_buffers()
@@ -790,15 +767,11 @@ EventDeliveryManager::gather_target_data( const thread tid )
     SendBufferPosition send_buffer_position( assigned_ranks,
       kernel().mpi_manager.get_send_recv_count_target_data_per_rank() );
 
-    me_completed_tid = collocate_target_data_buffers_(
+    const bool gather_completed = collocate_target_data_buffers_(
       tid, assigned_ranks, send_buffer_position );
-    completed_count_[ tid ] += static_cast< unsigned int >( me_completed_tid );
-#pragma omp barrier
+    gather_completed_checker_.logical_and( tid, gather_completed );
 
-    completed_count =
-      std::accumulate( completed_count_.begin(), completed_count_.end(), 0 );
-
-    if ( completed_count == half_completed_count )
+    if ( gather_completed_checker_.all_true() )
     {
       set_complete_marker_target_data_(
         tid, assigned_ranks, send_buffer_position );
@@ -826,9 +799,8 @@ EventDeliveryManager::gather_target_data( const thread tid )
 #endif
     } // of omp single
 
-    others_completed_tid = distribute_target_data_buffers_( tid );
-    completed_count_[ tid ] +=
-      static_cast< unsigned int >( others_completed_tid );
+    const bool distribute_completed = distribute_target_data_buffers_( tid );
+    gather_completed_checker_.logical_and( tid, distribute_completed );
 #pragma omp barrier
 
 #ifndef DISABLE_TIMING
@@ -838,14 +810,9 @@ EventDeliveryManager::gather_target_data( const thread tid )
     }
 #endif
 
-    completed_count =
-      std::accumulate( completed_count_.begin(), completed_count_.end(), 0 );
-
-    if ( completed_count == max_completed_count )
-    {
-      done = true;
-    }
-    else if ( kernel().mpi_manager.adaptive_target_buffers() )
+    // resize mpi buffers, if necessary and allowed
+    if ( not gather_completed_checker_.all_true()
+         and kernel().mpi_manager.adaptive_target_buffers() )
     {
 #pragma omp single
       {
@@ -854,7 +821,7 @@ EventDeliveryManager::gather_target_data( const thread tid )
       }
     }
 #pragma omp barrier
-  } // of while(true)
+  } // of while
 
   kernel().connection_manager.clear_source_table( tid );
 }

--- a/nestkernel/event_delivery_manager.h
+++ b/nestkernel/event_delivery_manager.h
@@ -33,6 +33,7 @@
 #include "stopwatch.h"
 
 // Includes from nestkernel:
+#include "completed_checker.h"
 #include "mpi_manager.h" // OffGridSpike
 #include "event.h"
 #include "nest_time.h"
@@ -467,7 +468,7 @@ private:
   // communication of spikes was
   // changed
 
-  std::vector< unsigned int > completed_count_;
+  CompletedChecker gather_completed_checker_;
 };
 
 inline void

--- a/nestkernel/event_delivery_manager.h
+++ b/nestkernel/event_delivery_manager.h
@@ -216,6 +216,8 @@ public:
    */
   void gather_secondary_target_data();
 
+  void write_done_marker_secondary_events_( const bool done );
+
   void gather_secondary_events( const bool done );
 
   bool deliver_secondary_events( const thread tid,


### PR DESCRIPTION
To simplify the `gather_` functions, this PR introduces a new thread-safe helper class to keep track of the progress of all threads in one MPI process.