### PR TITLE
Extended rate_transformer_node to non-linear summation

### DIFF
--- a/models/hh_psc_alpha_gap.cpp
+++ b/models/hh_psc_alpha_gap.cpp
@@ -719,8 +719,7 @@ nest::hh_psc_alpha_gap::handle( GapJunctionEvent& e )
   // The call to get_coeffvalue( it ) in this loop also advances the iterator it
   while ( it != e.end() )
   {
-    B_.interpolation_coefficients[ i ] +=
-      weight * e.get_coeffvalue( it );
+    B_.interpolation_coefficients[ i ] += weight * e.get_coeffvalue( it );
     ++i;
   }
 }

--- a/models/rate_neuron_ipn.h
+++ b/models/rate_neuron_ipn.h
@@ -55,8 +55,8 @@ namespace nest
  *  - mult_coupling_in (factor of multiplicative coupling for inhibitory input)
  *
  * The boolean parameter linear_summation determines whether the input function
- * is applied to the summed up incoming connections (= True, default value) or
- * to each input individually (= False). In case of multiplicative coupling the
+ * is applied to the summed up incoming connections (True, default value) or
+ * to each input individually (False). In case of multiplicative coupling the
  * nonlinearity is applied separately to the summed excitatory and inhibitory
  * inputs if linear_summation=True.
  *

--- a/models/rate_neuron_ipn_impl.h
+++ b/models/rate_neuron_ipn_impl.h
@@ -461,13 +461,13 @@ nest::rate_neuron_ipn< TNonlinearities >::handle(
     {
       if ( weight >= 0.0 )
       {
-        B_.delayed_rates_ex_.add_value( delay + i,
-          weight * nonlinearities_.input( e.get_coeffvalue( it ) ) );
+        B_.delayed_rates_ex_.add_value(
+          delay + i, weight * nonlinearities_.input( e.get_coeffvalue( it ) ) );
       }
       else
       {
-        B_.delayed_rates_in_.add_value( delay + i,
-          weight * nonlinearities_.input( e.get_coeffvalue( it ) ) );
+        B_.delayed_rates_in_.add_value(
+          delay + i, weight * nonlinearities_.input( e.get_coeffvalue( it ) ) );
       }
     }
     ++i;

--- a/models/rate_neuron_opn.h
+++ b/models/rate_neuron_opn.h
@@ -55,8 +55,8 @@ namespace nest
  *  - mult_coupling_in (factor of multiplicative coupling for inhibitory input)
  *
  * The boolean parameter linear_summation determines whether the input function
- * is applied to the summed up incoming connections (= True, default value) or
- * to each input individually (= False). In case of multiplicative coupling the
+ * is applied to the summed up incoming connections (True, default value) or
+ * to each input individually (False). In case of multiplicative coupling the
  * nonlinearity is applied separately to the summed excitatory and inhibitory
  * inputs if linear_summation=True.
  *

--- a/models/rate_neuron_opn_impl.h
+++ b/models/rate_neuron_opn_impl.h
@@ -426,24 +426,26 @@ nest::rate_neuron_opn< TNonlinearities >::handle(
     {
       if ( weight >= 0.0 )
       {
-        B_.delayed_rates_ex_.add_value( delay + i, weight * e.get_coeffvalue( it ) );
+        B_.delayed_rates_ex_.add_value(
+          delay + i, weight * e.get_coeffvalue( it ) );
       }
       else
       {
-        B_.delayed_rates_in_.add_value( delay + i, weight * e.get_coeffvalue( it ) );
+        B_.delayed_rates_in_.add_value(
+          delay + i, weight * e.get_coeffvalue( it ) );
       }
     }
     else
     {
       if ( weight >= 0.0 )
       {
-        B_.delayed_rates_ex_.add_value( delay + i,
-          weight * nonlinearities_.input( e.get_coeffvalue( it ) ) );
+        B_.delayed_rates_ex_.add_value(
+          delay + i, weight * nonlinearities_.input( e.get_coeffvalue( it ) ) );
       }
       else
       {
-        B_.delayed_rates_in_.add_value( delay + i,
-          weight * nonlinearities_.input( e.get_coeffvalue( it ) ) );
+        B_.delayed_rates_in_.add_value(
+          delay + i, weight * nonlinearities_.input( e.get_coeffvalue( it ) ) );
       }
     }
     ++i;

--- a/models/rate_transformer_node.h
+++ b/models/rate_transformer_node.h
@@ -51,8 +51,11 @@ Name: rate_transformer_node - Rate neuron that sums up incoming rates
 
 Description:
 
-The rate transformer node simply sums up all incoming rates and applies
-the nonlinearity specified in the function input of the template class.
+The rate transformer node simply applies the nonlinearity specified in the
+input-function of the template class to all incoming inputs. The boolean
+parameter linear_summation determines whether the input function is applied to
+the summed up incoming connections (= True, default value) or to each input
+individually (= False).
 An important application is to provide the possibility to
 apply different nonlinearities to different incoming connections of the
 same rate neuron by connecting the sending rate neurons to the
@@ -72,8 +75,8 @@ Receives: InstantaneousRateConnectionEvent, DelayedRateConnectionEvent
 Sends: InstantaneousRateConnectionEvent, DelayedRateConnectionEvent
 
 Parameters:
-Only the parameters from the class Nonlinearities can be set in the
-status dictionary.
+Only the parameter linear_summation and the parameters from the
+class Nonlinearities can be set in the status dictionary.
 
 Author: Mario Senden, Jan Hahne, Jannis Schuecker
 FirstVersion: November 2017
@@ -137,6 +140,25 @@ private:
   friend class RecordablesMap< rate_transformer_node< TNonlinearities > >;
   friend class UniversalDataLogger< rate_transformer_node< TNonlinearities > >;
 
+  // ----------------------------------------------------------------
+
+  /**
+   * Independent parameters of the model.
+   */
+  struct Parameters_
+  {
+    /** Target of non-linearity.
+        True (default): Gain function applied to linearly summed input.
+        False: Gain function applied to each input before summation.
+    **/
+    bool linear_summation_;
+
+    Parameters_(); //!< Sets default parameter values
+
+    void get( DictionaryDatum& ) const; //!< Store current values in dictionary
+
+    void set( const DictionaryDatum& );
+  };
 
   // ----------------------------------------------------------------
 
@@ -194,6 +216,7 @@ private:
 
   // ----------------------------------------------------------------
 
+  Parameters_ P_;
   State_ S_;
   Buffers_ B_;
 
@@ -267,6 +290,7 @@ template < class TNonlinearities >
 inline void
 rate_transformer_node< TNonlinearities >::get_status( DictionaryDatum& d ) const
 {
+  P_.get( d );
   S_.get( d );
   Archiving_Node::get_status( d );
   ( *d )[ names::recordables ] = recordablesMap_.get_list();
@@ -278,8 +302,10 @@ template < class TNonlinearities >
 inline void
 rate_transformer_node< TNonlinearities >::set_status( const DictionaryDatum& d )
 {
-  State_ stmp = S_; // temporary copy in case of errors
-  stmp.set( d );    // throws if BadProperty
+  Parameters_ ptmp = P_; // temporary copy in case of errors
+  ptmp.set( d );         // throws if BadProperty
+  State_ stmp = S_;      // temporary copy in case of errors
+  stmp.set( d );         // throws if BadProperty
 
   // We now know that (stmp) is consistent. We do not
   // write it back to (S_) before we are also sure that
@@ -288,6 +314,7 @@ rate_transformer_node< TNonlinearities >::set_status( const DictionaryDatum& d )
   Archiving_Node::set_status( d );
 
   // if we get here, temporaries contain consistent set of properties
+  P_ = ptmp;
   S_ = stmp;
 
   nonlinearities_.set( d );

--- a/models/rate_transformer_node.h
+++ b/models/rate_transformer_node.h
@@ -54,8 +54,8 @@ Description:
 The rate transformer node simply applies the nonlinearity specified in the
 input-function of the template class to all incoming inputs. The boolean
 parameter linear_summation determines whether the input function is applied to
-the summed up incoming connections (= True, default value) or to each input
-individually (= False).
+the summed up incoming connections (True, default value) or to each input
+individually (False).
 An important application is to provide the possibility to
 apply different nonlinearities to different incoming connections of the
 same rate neuron by connecting the sending rate neurons to the

--- a/models/rate_transformer_node_impl.h
+++ b/models/rate_transformer_node_impl.h
@@ -63,6 +63,13 @@ RecordablesMap< rate_transformer_node< TNonlinearities > >
  * ---------------------------------------------------------------- */
 
 template < class TNonlinearities >
+nest::rate_transformer_node< TNonlinearities >::Parameters_::Parameters_()
+  : linear_summation_( true )
+{
+  recordablesMap_.create();
+}
+
+template < class TNonlinearities >
 nest::rate_transformer_node< TNonlinearities >::State_::State_()
   : rate_( 0.0 )
 {
@@ -71,6 +78,22 @@ nest::rate_transformer_node< TNonlinearities >::State_::State_()
 /* ----------------------------------------------------------------
  * Parameter and state extractions and manipulation functions
  * ---------------------------------------------------------------- */
+
+template < class TNonlinearities >
+void
+nest::rate_transformer_node< TNonlinearities >::Parameters_::get(
+  DictionaryDatum& d ) const
+{
+  def< bool >( d, names::linear_summation, linear_summation_ );
+}
+
+template < class TNonlinearities >
+void
+nest::rate_transformer_node< TNonlinearities >::Parameters_::set(
+  const DictionaryDatum& d )
+{
+  updateValue< bool >( d, names::linear_summation, linear_summation_ );
+}
 
 template < class TNonlinearities >
 void
@@ -192,12 +215,30 @@ nest::rate_transformer_node< TNonlinearities >::update_( Time const& origin,
     // reinitialize output rate
     S_.rate_ = 0.0;
 
-    if ( called_from_wfr_update ) // use get_value_wfr_update to keep values in
-                                  // buffer
+    double delayed_rates = 0;
+    if ( called_from_wfr_update )
     {
-      S_.rate_ += nonlinearities_.input( B_.delayed_rates_.get_value_wfr_update(
-                                           lag ) + B_.instant_rates_[ lag ] );
+      // use get_value_wfr_update to keep values in buffer
+      delayed_rates = B_.delayed_rates_.get_value_wfr_update( lag );
+    }
+    else
+    {
+      // use get_value to clear values in buffer after reading
+      delayed_rates = B_.delayed_rates_.get_value( lag );
+    }
 
+    if ( P_.linear_summation_ )
+    {
+      S_.rate_ +=
+        nonlinearities_.input( delayed_rates + B_.instant_rates_[ lag ] );
+    }
+    else
+    {
+      S_.rate_ += delayed_rates + B_.instant_rates_[ lag ];
+    }
+
+    if ( called_from_wfr_update )
+    {
       // check if deviation from last iteration exceeds wfr_tol
       wfr_tol_exceeded = wfr_tol_exceeded
         or fabs( S_.rate_ - B_.last_y_values[ lag ] ) > wfr_tol;
@@ -206,8 +247,6 @@ nest::rate_transformer_node< TNonlinearities >::update_( Time const& origin,
     }
     else
     {
-      S_.rate_ += nonlinearities_.input(
-        B_.delayed_rates_.get_value( lag ) + B_.instant_rates_[ lag ] );
       // rate logging
       B_.logger_.record_data( origin.get_steps() + lag );
     }
@@ -255,7 +294,15 @@ nest::rate_transformer_node< TNonlinearities >::handle(
   // The call to get_coeffvalue( it ) in this loop also advances the iterator it
   while ( it != e.end() )
   {
-    B_.instant_rates_[ i ] += weight * e.get_coeffvalue( it );
+    if ( P_.linear_summation_ )
+    {
+      B_.instant_rates_[ i ] += weight * e.get_coeffvalue( it );
+    }
+    else
+    {
+      B_.instant_rates_[ i ] +=
+        weight * nonlinearities_.input( e.get_coeffvalue( it ) );
+    }
     ++i;
   }
 }
@@ -273,9 +320,15 @@ nest::rate_transformer_node< TNonlinearities >::handle(
   // The call to get_coeffvalue( it ) in this loop also advances the iterator it
   while ( it != e.end() )
   {
-    B_.delayed_rates_.add_value(
-      delay + i,
-      weight * e.get_coeffvalue( it ) );
+    if ( P_.linear_summation_ )
+    {
+      B_.delayed_rates_.add_value( delay + i, weight * e.get_coeffvalue( it ) );
+    }
+    else
+    {
+      B_.delayed_rates_.add_value(
+        delay + i, weight * nonlinearities_.input( e.get_coeffvalue( it ) ) );
+    }
     ++i;
   }
 }

--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -1643,6 +1643,7 @@ nest::ConnectionManager::remove_disabled_connections( const thread tid )
   }
 }
 
+void
 nest::ConnectionManager::resize_connections()
 {
   kernel().vp_manager.assert_single_threaded();


### PR DESCRIPTION
This PR extends the `rate_transformer_node` to non-linear summation.

@jakobj and @heplesser  I was not sure where to put this PR. Since 5g changes the corresponding parts of the code significantly, a PR of the 4g code to the main repository would only result in an unnecessary merge conflict for 5g. You might as well close this PR here if it is not reviewed and merged at the time when 5g is ready for merge to master. However, I would like this to be part of NEST 2.16.0. 