### PR TITLE
Fixed deadlock when getting connections

### DIFF
--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -1160,13 +1160,6 @@ nest::ConnectionManager::get_connections(
       "cleared." );
   }
 
-  const size_t num_connections = get_num_connections( syn_id );
-
-  if ( num_connections == 0 )
-  {
-    return;
-  }
-
   // if connections have changed, (re-)build presynaptic infrastructure,
   // as this may involve sorting connections by source gids
   if ( have_connections_changed() )
@@ -1643,6 +1636,7 @@ nest::ConnectionManager::remove_disabled_connections( const thread tid )
   }
 }
 
+void
 nest::ConnectionManager::resize_connections()
 {
   kernel().vp_manager.assert_single_threaded();

--- a/pynest/nest/tests/test_connect_all_to_all.py
+++ b/pynest/nest/tests/test_connect_all_to_all.py
@@ -39,8 +39,6 @@ class TestAllToAll(TestParams):
     N1_array = 500
     N2_array = 10
 
-    # def testErrorMessages(self):
-
     def testConnectivity(self):
         self.setUpNetwork(self.conn_dict)
         # make sure all connections do exist
@@ -121,7 +119,7 @@ class TestAllToAll(TestParams):
     def testRPortDistribution(self):
         n_rport = 10
         nr_neurons = 20
-        hf.nest.ResetKernel()
+        hf.nest.ResetKernel()  # To reset local_num_threads
         neuron_model = 'iaf_psc_exp_multisynapse'
         neuron_dict = {'tau_syn': [0.1 + i for i in range(n_rport)]}
         self.pop1 = hf.nest.Create(neuron_model, nr_neurons, neuron_dict)

--- a/pynest/nest/tests/test_connect_all_to_all.py
+++ b/pynest/nest/tests/test_connect_all_to_all.py
@@ -63,6 +63,7 @@ class TestAllToAll(TestParams):
                     1, self.N1_array * self.N2_array + 1
                 ).reshape(self.N2_array, self.N1_array) * 0.1
             syn_params[label] = self.param_array
+            hf.nest.ResetKernel()
             self.setUpNetwork(self.conn_dict, syn_params,
                               N1=self.N1_array, N2=self.N2_array)
             M_nest = hf.get_weighted_connectivity_matrix(

--- a/pynest/nest/tests/test_connect_fixed_indegree.py
+++ b/pynest/nest/tests/test_connect_fixed_indegree.py
@@ -26,8 +26,6 @@ import scipy.stats
 from . import test_connect_helpers as hf
 from .test_connect_parameters import TestParams
 
-from time import time
-
 
 class TestFixedInDegree(TestParams):
 
@@ -56,7 +54,7 @@ class TestFixedInDegree(TestParams):
         conn_params['indegree'] = self.N1 + 1
         try:
             self.setUpNetwork(conn_params)
-        except:
+        except hf.nest.NESTError:
             got_error = True
         self.assertTrue(got_error)
 
@@ -96,7 +94,7 @@ class TestFixedInDegree(TestParams):
             ks, p = scipy.stats.kstest(pvalues, 'uniform')
             self.assertTrue(p > self.stat_dict['alpha2'])
 
-    def testAutapses(self):
+    def testAutapsesTrue(self):
         conn_params = self.conn_dict.copy()
         N = 10
         conn_params['multapses'] = False
@@ -109,7 +107,11 @@ class TestFixedInDegree(TestParams):
         # make sure all connections do exist
         M = hf.get_connectivity_matrix(pop, pop)
         hf.mpi_assert(np.diag(M), np.ones(N), self)
-        hf.nest.ResetKernel()
+
+    def testAutapsesFalse(self):
+        conn_params = self.conn_dict.copy()
+        N = 10
+        conn_params['multapses'] = False
 
         # test that autapses were excluded
         conn_params['indegree'] = N - 1
@@ -120,7 +122,7 @@ class TestFixedInDegree(TestParams):
         M = hf.get_connectivity_matrix(pop, pop)
         hf.mpi_assert(np.diag(M), np.zeros(N), self)
 
-    def testMultapses(self):
+    def testMultapsesTrue(self):
         conn_params = self.conn_dict.copy()
         N = 3
         conn_params['autapses'] = True
@@ -132,7 +134,11 @@ class TestFixedInDegree(TestParams):
         hf.nest.Connect(pop, pop, conn_params)
         nr_conns = len(hf.nest.GetConnections(pop, pop))
         hf.mpi_assert(nr_conns, conn_params['indegree'] * N, self)
-        hf.nest.ResetKernel()
+
+    def testMultapsesFalse(self):
+        conn_params = self.conn_dict.copy()
+        N = 3
+        conn_params['autapses'] = True
 
         # test that no multapses exist
         conn_params['indegree'] = N
@@ -153,6 +159,7 @@ def suite():
 def run():
     runner = unittest.TextTestRunner(verbosity=2)
     runner.run(suite())
+
 
 if __name__ == '__main__':
     run()

--- a/pynest/nest/tests/test_connect_fixed_outdegree.py
+++ b/pynest/nest/tests/test_connect_fixed_outdegree.py
@@ -52,7 +52,7 @@ class TestFixedOutDegree(TestParams):
         conn_params['outdegree'] = self.N2 + 1
         try:
             self.setUpNetwork(conn_params)
-        except:
+        except hf.nest.NESTError:
             got_error = True
         self.assertTrue(got_error)
 
@@ -92,7 +92,7 @@ class TestFixedOutDegree(TestParams):
             ks, p = scipy.stats.kstest(pvalues, 'uniform')
             self.assertTrue(p > self.stat_dict['alpha2'])
 
-    def testAutapses(self):
+    def testAutapsesTrue(self):
         conn_params = self.conn_dict.copy()
         N = 10
         conn_params['multapses'] = False
@@ -105,7 +105,11 @@ class TestFixedOutDegree(TestParams):
         # make sure all connections do exist
         M = hf.get_connectivity_matrix(pop, pop)
         hf.mpi_assert(np.diag(M), np.ones(N), self)
-        hf.nest.ResetKernel()
+
+    def testAutapsesFalse(self):
+        conn_params = self.conn_dict.copy()
+        N = 10
+        conn_params['multapses'] = False
 
         # test that autapses were excluded
         conn_params['outdegree'] = N - 1
@@ -116,7 +120,7 @@ class TestFixedOutDegree(TestParams):
         M = hf.get_connectivity_matrix(pop, pop)
         hf.mpi_assert(np.diag(M), np.zeros(N), self)
 
-    def testMultapses(self):
+    def testMultapsesTrue(self):
         conn_params = self.conn_dict.copy()
         N = 3
         conn_params['autapses'] = True
@@ -128,7 +132,11 @@ class TestFixedOutDegree(TestParams):
         hf.nest.Connect(pop, pop, conn_params)
         nr_conns = len(hf.nest.GetConnections(pop, pop))
         hf.mpi_assert(nr_conns, conn_params['outdegree'] * N, self)
-        hf.nest.ResetKernel()
+
+    def testMultapsesFalse(self):
+        conn_params = self.conn_dict.copy()
+        N = 3
+        conn_params['autapses'] = True
 
         # test that no multapses exist
         conn_params['outdegree'] = N
@@ -149,6 +157,7 @@ def suite():
 def run():
     runner = unittest.TextTestRunner(verbosity=2)
     runner.run(suite())
+
 
 if __name__ == '__main__':
     run()

--- a/pynest/nest/tests/test_connect_fixed_total_number.py
+++ b/pynest/nest/tests/test_connect_fixed_total_number.py
@@ -23,8 +23,6 @@ import numpy as np
 import unittest
 import scipy.stats
 
-from . import compatibility
-
 from . import test_connect_helpers as hf
 from .test_connect_parameters import TestParams
 
@@ -56,7 +54,7 @@ class TestFixedTotalNumber(TestParams):
         conn_params['N'] = self.N1 * self.N2 + 1
         try:
             self.setUpNetwork(conn_params)
-        except:
+        except hf.nest.NESTError:
             got_error = True
         self.assertTrue(got_error)
 
@@ -94,7 +92,7 @@ class TestFixedTotalNumber(TestParams):
                 ks, p = scipy.stats.kstest(pvalues, 'uniform')
                 self.assertTrue(p > self.stat_dict['alpha2'])
 
-    def testAutapses(self):
+    def testAutapsesTrue(self):
         conn_params = self.conn_dict.copy()
         N = 3
 
@@ -108,7 +106,10 @@ class TestFixedTotalNumber(TestParams):
         M = hf.gather_data(M)
         if M is not None:
             self.assertTrue(np.sum(np.diag(M)) > N)
-        hf.nest.ResetKernel()
+
+    def testAutapsesFalse(self):
+        conn_params = self.conn_dict.copy()
+        N = 3
 
         # test that autapses were excluded
         conn_params['N'] = N * (N - 1)

--- a/pynest/nest/tests/test_connect_one_to_one.py
+++ b/pynest/nest/tests/test_connect_one_to_one.py
@@ -36,8 +36,6 @@ class TestOneToOne(TestParams):
     N2 = N
     N_array = 1000
 
-    # def testErrorMessages(self):
-
     def testConnectivity(self):
         self.setUpNetwork(self.conn_dict)
         # make sure all connections do exist

--- a/pynest/nest/tests/test_connect_one_to_one.py
+++ b/pynest/nest/tests/test_connect_one_to_one.py
@@ -65,6 +65,7 @@ class TestOneToOne(TestParams):
             elif label == 'delay':
                 self.param_array = np.arange(1, self.N_array + 1) * 0.1
             syn_params[label] = self.param_array
+            hf.nest.ResetKernel()
             self.setUpNetwork(self.conn_dict, syn_params,
                               N1=self.N_array, N2=self.N_array)
             M_nest = hf.get_weighted_connectivity_matrix(

--- a/pynest/nest/tests/test_connect_pairwise_bernoulli.py
+++ b/pynest/nest/tests/test_connect_pairwise_bernoulli.py
@@ -62,7 +62,7 @@ class TestPairwiseBernoulli(TestParams):
                 ks, p = scipy.stats.kstest(pvalues, 'uniform')
                 self.assertTrue(p > self.stat_dict['alpha2'])
 
-    def testAutapses(self):
+    def testAutapsesTrue(self):
         conn_params = self.conn_dict.copy()
         N = 10
         conn_params['multapses'] = False
@@ -75,7 +75,11 @@ class TestPairwiseBernoulli(TestParams):
         # make sure all connections do exist
         M = hf.get_connectivity_matrix(pop, pop)
         hf.mpi_assert(np.diag(M), np.ones(N), self)
-        hf.nest.ResetKernel()
+
+    def testAutapsesFalse(self):
+        conn_params = self.conn_dict.copy()
+        N = 10
+        conn_params['multapses'] = False
 
         # test that autapses were excluded
         conn_params['p'] = 1.

--- a/pynest/nest/tests/test_connect_parameters.py
+++ b/pynest/nest/tests/test_connect_parameters.py
@@ -58,7 +58,6 @@ class TestParams(unittest.TestCase):
     def setUp(self):
         hf.nest.ResetKernel()
         hf.nest.SetKernelStatus({'local_num_threads': self.nr_threads})
-        # pass
 
     def setUpNetwork(self, conn_dict=None, syn_dict=None, N1=None, N2=None):
         if N1 is None:
@@ -132,7 +131,7 @@ class TestParams(unittest.TestCase):
         self.assertTrue(all(x['receptor'] == self.r0 for x in conns))
         self.assertTrue(all(x['synapse_model'] == self.syn0 for x in conns))
 
-    def testAutapses(self):
+    def testAutapsesTrue(self):
         conn_params = self.conn_dict.copy()
 
         # test that autapses exist
@@ -142,7 +141,9 @@ class TestParams(unittest.TestCase):
         # make sure all connections do exist
         M = hf.get_connectivity_matrix(self.pop1, self.pop1)
         hf.mpi_assert(np.diag(M), np.ones(self.N1), self)
-        hf.nest.ResetKernel()
+
+    def testAutapsesFalse(self):
+        conn_params = self.conn_dict.copy()
 
         # test that autapses were excluded
         conn_params['autapses'] = False
@@ -240,8 +241,7 @@ class TestParams(unittest.TestCase):
             conn_params = [conn['receptor'] for conn in conns]
             self.assertTrue(hf.all_equal(conn_params))
             self.assertTrue(conn_params[0] == syn_params['receptor_type'])
-            hf.nest.ResetKernel()
-            self.setUp
+            self.setUp()
 
     def testWeightAllSynapses(self):
         # test all synapses apart from static_synapse_hom_w where weight is not
@@ -255,7 +255,7 @@ class TestParams(unittest.TestCase):
                 ]
         syn_params = {'weight': 0.372}
 
-        for i, syn in enumerate(syns):
+        for syn in syns:
             if syn == 'stdp_dopamine_synapse':
                 vol = hf.nest.Create('volume_transmitter')
                 hf.nest.SetDefaults('stdp_dopamine_synapse', {'vt': vol[0]})
@@ -275,7 +275,7 @@ class TestParams(unittest.TestCase):
                 ]
         syn_params = {'delay': 0.4}
 
-        for i, syn in enumerate(syns):
+        for syn in syns:
             if syn == 'stdp_dopamine_synapse':
                 vol = hf.nest.Create('volume_transmitter')
                 hf.nest.SetDefaults('stdp_dopamine_synapse', {'vt': vol[0]})

--- a/pynest/nest/tests/test_connect_symmetric_pairwise_bernoulli.py
+++ b/pynest/nest/tests/test_connect_symmetric_pairwise_bernoulli.py
@@ -64,21 +64,23 @@ class TestSymmetricPairwiseBernoulli(TestParams):
                 ks, p = scipy.stats.kstest(pvalues, 'uniform')
                 self.assertTrue(p > self.stat_dict['alpha2'])
 
-    def testAutapses(self):
+    def testAutapsesTrue(self):
         conn_params = self.conn_dict.copy()
         conn_params['autapses'] = True
         N = 10
 
         # test that autapses are not permitted
-        hf.nest.ResetKernel()
         pop = hf.nest.Create('iaf_psc_alpha', N)
         with self.assertRaises(hf.nest.NESTError):
             hf.nest.Connect(pop, pop, conn_params)
 
+    def testAutapsesFalse(self):
+        conn_params = self.conn_dict.copy()
+        N = 10
+
         # test that autapses were excluded
         conn_params['p'] = 1. - 1. / N
         conn_params['autapses'] = False
-        hf.nest.ResetKernel()
         pop = hf.nest.Create('iaf_psc_alpha', N)
         hf.nest.Connect(pop, pop, conn_params)
         M = hf.get_connectivity_matrix(pop, pop)


### PR DESCRIPTION
Fixed an issue where getting connections with a certain number of connections, with MPI, but without threading, would create a deadlock. This caused installcheck to hang when running `testAutapses` using two processes.

When using a certain number of connections, one process wouldn't get any connections, therefore returning from `get_connections()` early. When the other process then tried to communicate, it created a deadlock. This PR removes the possibility to return early.

Also restored a `void` that got lost in an earlier merge.