### PR TITLE
Reset sort_connections_by_source_ to true when calling ResetKernel

### DIFF
--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -91,6 +91,7 @@ nest::ConnectionManager::initialize()
   const thread num_threads = kernel().vp_manager.get_num_threads();
   connections_.resize( num_threads, NULL );
   secondary_recv_buffer_pos_.resize( num_threads, NULL );
+  sort_connections_by_source_ = true;
 
 #pragma omp parallel
   {


### PR DESCRIPTION
If you have set `sort_connections_by_source` to `false` with `SetKernelStatus` and do a `ResetKernel`, `sort_connections_by_source` is not reset, so this PR resets the variable to `true` when calling `ResetKernel`.