### PR TITLE
GetConnections performance improvement

### DIFF
--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -1245,17 +1245,17 @@ nest::ConnectionManager::get_connections(
 
       std::deque< ConnectionID > conns_in_thread;
 
-      // Split targets into node- and device-vectors.
-      std::vector< index > target_nodes;
-      std::vector< index > target_devices;
+      // Split targets into neuron- and device-vectors.
+      std::vector< index > target_neuron_gids;
+      std::vector< index > target_device_gids;
       split_to_neuron_device_vectors_(
         tid, target, target_neuron_gids, target_device_gids );
 
       ConnectorBase* connections = ( *connections_[ tid ] )[ syn_id ];
       if ( connections != NULL )
       {
-        for ( std::vector< index >::const_iterator t_gid = target_nodes.begin();
-              t_gid != target_nodes.end();
+        for ( std::vector< index >::const_iterator t_gid = target_neuron_gids.begin();
+              t_gid != target_neuron_gids.end();
               ++t_gid )
         {
 
@@ -1271,13 +1271,15 @@ nest::ConnectionManager::get_connections(
               syn_id,
               source_lcids[ i ] ) ) );
           }
+          // target_table_devices_ contains connections both to and from
+          // devices.
           target_table_devices_.get_connections_from_devices_(
             0, *t_gid, tid, syn_id, synapse_label, conns_in_thread );
         }
       }
 
-      for ( std::vector< index >::const_iterator t_gid = target_devices.begin();
-            t_gid != target_devices.end();
+      for ( std::vector< index >::const_iterator t_gid = target_device_gids.begin();
+            t_gid != target_device_gids.end();
             ++t_gid )
       {
         target_table_devices_.get_connections_to_devices_(
@@ -1306,8 +1308,9 @@ nest::ConnectionManager::get_connections(
       source->toVector( sources );
       std::sort( sources.begin(), sources.end() );
 
-      std::vector< index > target_nodes;
-      std::vector< index > target_devices;
+      // Split targets into neuron- and device-vectors.
+      std::vector< index > target_neuron_gids;
+      std::vector< index > target_device_gids;
       if ( target != 0 )
       {
       split_to_neuron_device_vectors_(
@@ -1334,8 +1337,8 @@ nest::ConnectionManager::get_connections(
             else
             {
               for ( std::vector< index >::const_iterator t_gid =
-                      target_nodes.begin();
-                    t_gid != target_nodes.end();
+                      target_neuron_gids.begin();
+                    t_gid != target_neuron_gids.end();
                     ++t_gid )
               {
                 connections->get_connection( source_gid,
@@ -1361,16 +1364,18 @@ nest::ConnectionManager::get_connections(
         else
         {
           for (
-            std::vector< index >::const_iterator t_gid = target_nodes.begin();
-            t_gid != target_nodes.end();
+            std::vector< index >::const_iterator t_gid = target_neuron_gids.begin();
+            t_gid != target_neuron_gids.end();
             ++t_gid )
           {
+            // target_table_devices_ contains connections both to and from
+            // devices.
             target_table_devices_.get_connections_from_devices_(
               source_gid, *t_gid, tid, syn_id, synapse_label, conns_in_thread );
           }
           for (
-            std::vector< index >::const_iterator t_gid = target_devices.begin();
-            t_gid != target_devices.end();
+            std::vector< index >::const_iterator t_gid = target_device_gids.begin();
+            t_gid != target_device_gids.end();
             ++t_gid )
           {
             target_table_devices_.get_connections_to_devices_(

--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -1254,7 +1254,8 @@ nest::ConnectionManager::get_connections(
       ConnectorBase* connections = ( *connections_[ tid ] )[ syn_id ];
       if ( connections != NULL )
       {
-        for ( std::vector< index >::const_iterator t_gid = target_neuron_gids.begin();
+        for ( std::vector< index >::const_iterator t_gid =
+                target_neuron_gids.begin();
               t_gid != target_neuron_gids.end();
               ++t_gid )
         {
@@ -1278,9 +1279,10 @@ nest::ConnectionManager::get_connections(
         }
       }
 
-      for ( std::vector< index >::const_iterator t_gid = target_device_gids.begin();
-            t_gid != target_device_gids.end();
-            ++t_gid )
+      for (
+        std::vector< index >::const_iterator t_gid = target_device_gids.begin();
+        t_gid != target_device_gids.end();
+        ++t_gid )
       {
         target_table_devices_.get_connections_to_devices_(
           0, *t_gid, tid, syn_id, synapse_label, conns_in_thread );
@@ -1313,8 +1315,8 @@ nest::ConnectionManager::get_connections(
       std::vector< index > target_device_gids;
       if ( target != 0 )
       {
-      split_to_neuron_device_vectors_(
-        tid, target, target_neuron_gids, target_device_gids );
+        split_to_neuron_device_vectors_(
+          tid, target, target_neuron_gids, target_device_gids );
       }
 
       const ConnectorBase* connections = ( *connections_[ tid ] )[ syn_id ];
@@ -1363,20 +1365,20 @@ nest::ConnectionManager::get_connections(
         }
         else
         {
-          for (
-            std::vector< index >::const_iterator t_gid = target_neuron_gids.begin();
-            t_gid != target_neuron_gids.end();
-            ++t_gid )
+          for ( std::vector< index >::const_iterator t_gid =
+                  target_neuron_gids.begin();
+                t_gid != target_neuron_gids.end();
+                ++t_gid )
           {
             // target_table_devices_ contains connections both to and from
             // devices.
             target_table_devices_.get_connections_from_devices_(
               source_gid, *t_gid, tid, syn_id, synapse_label, conns_in_thread );
           }
-          for (
-            std::vector< index >::const_iterator t_gid = target_device_gids.begin();
-            t_gid != target_device_gids.end();
-            ++t_gid )
+          for ( std::vector< index >::const_iterator t_gid =
+                  target_device_gids.begin();
+                t_gid != target_device_gids.end();
+                ++t_gid )
           {
             target_table_devices_.get_connections_to_devices_(
               source_gid, *t_gid, tid, syn_id, synapse_label, conns_in_thread );

--- a/nestkernel/connection_manager.h
+++ b/nestkernel/connection_manager.h
@@ -437,6 +437,15 @@ private:
     std::vector< index >& sources );
 
   /**
+   * Splits a TokenArray of GIDs to two vectors containing GIDs of neurons and
+   * GIDs of devices.
+   */
+  void split_to_neuron_device_vectors_( const thread tid,
+    TokenArray const* gid_token_array,
+    std::vector< index >& neuron_gids,
+    std::vector< index >& device_gids ) const;
+
+  /**
    * Update delay extrema to current values.
    *
    * Static since it only operates in static variables. This allows it to be


### PR DESCRIPTION
This PR makes some improvements to performance of GetConnections, dealing with the issue of it being a lot slower in 5g than in master. However, there is still a scaling problem when calling GetConnections with both source and target arguments.

Now GetConnections sort target nodes in two arrays, to reduce the time spent searching in `target_table_devices_`. This means that the cases with only sources as argument or without any arguments to GetConnections are unchanged, but these run-times were comparable to master anyway.

As a benchmark, I used the SLI script
```
0 << /local_num_threads t >> SetStatus
/N 10000 def 

/beg 0 /network_size get def
/end1 /iaf_psc_alpha N Create def
/p1 [beg end1] Range def

/beg 0 /network_size get def
/end2 /iaf_psc_alpha N Create def
/p2 [beg end2] Range def

p1 p2 << /rule /one_to_one >> Connect
<< /source p1 /target p2 >> GetConnections
```
where `t` is number of threads, and call this with `mpirun -n p`, where `p` is the number of processes. This results in the following run-times, given in seconds, averaged over 3 runs:

|      | master | 5g   | PR   |
|------|--------|------|------|
| **p=1, t=1** | 2.52   | 5.16 | 0.86 |
| **p=1, t=2** | 2.47   | 8.12 | 1.13 |
| **p=2, t=1** | 1.43   | 4.68 | 0.69 |
| **p=2, t=2** | 1.41   | 8.09 | 0.99 |

And for the case with only targets as argument to GetConnections:

|      | master | 5g   | PR   |
|------|--------|------|------|
| **p=1, t=1** | 2.52   | 2.82 | 0.45 |
| **p=1, t=2** | 2.43   | 2.90 | 0.43 |
| **p=2, t=1** | 1.45   | 1.59 | 0.29 |
| **p=2, t=2** | 1.43   | 1.64 | 0.29 |