### PR TITLE
Record spikes of final simulation step

### DIFF
--- a/models/spike_detector.cpp
+++ b/models/spike_detector.cpp
@@ -181,3 +181,16 @@ nest::spike_detector::handle( SpikeEvent& e )
     }
   }
 }
+
+void
+nest::spike_detector::finalize()
+{
+  // The order of the major simulation steps is:
+  // update nodes -- gather spikes -- deliver spikes
+  // Therefore, spikes from the last deliver might still reside in the
+  // B_.spikes_ buffer and need to be recorded.
+  // --> final call to update()
+  const Time time;
+  update( time, -1, -1 );
+  device_.finalize();
+}

--- a/models/spike_detector.h
+++ b/models/spike_detector.h
@@ -195,13 +195,6 @@ spike_detector::post_run_cleanup()
   device_.post_run_cleanup();
 }
 
-
-inline void
-spike_detector::finalize()
-{
-  device_.finalize();
-}
-
 inline SignalType
 spike_detector::receives_signal() const
 {


### PR DESCRIPTION
The order of the major simulation steps is: update nodes -- gather spikes -- deliver spikes.

Therefore, in `spike_detector` spikes from the last deliver might still reside in the
`B_.spikes_` buffer and need to be recorded. A final call to `update()` in `finalize()` can achieve this.