### PR TITLE
Initialize and reset variables in the EventDeliveryManager

### DIFF
--- a/nestkernel/event_delivery_manager.cpp
+++ b/nestkernel/event_delivery_manager.cpp
@@ -84,8 +84,10 @@ EventDeliveryManager::initialize()
   spike_register_.resize( num_threads, NULL );
   off_grid_spike_register_.resize( num_threads, NULL );
   gather_completed_checker_.resize( num_threads, false );
-  // ensures that ResetKernel resets off_grid_spiking_
+  // Ensures that ResetKernel resets off_grid_spiking_
   off_grid_spiking_ = false;
+  buffer_size_target_data_has_changed_ = false;
+  buffer_size_spike_data_has_changed_ = false;
 
 #pragma omp parallel
   {
@@ -145,8 +147,6 @@ EventDeliveryManager::finalize()
   recv_buffer_spike_data_.clear();
   send_buffer_off_grid_spike_data_.clear();
   recv_buffer_off_grid_spike_data_.clear();
-  buffer_size_target_data_has_changed_ = false;
-  buffer_size_spike_data_has_changed_ = false;
 }
 
 void

--- a/nestkernel/event_delivery_manager.h
+++ b/nestkernel/event_delivery_manager.h
@@ -25,8 +25,8 @@
 
 // C++ includes:
 #include <cassert>
-#include <vector>
 #include <limits>
+#include <vector>
 
 // Includes from libnestutil:
 #include "manager_interface.h"
@@ -34,8 +34,8 @@
 
 // Includes from nestkernel:
 #include "completed_checker.h"
-#include "mpi_manager.h" // OffGridSpike
 #include "event.h"
+#include "mpi_manager.h" // OffGridSpike
 #include "nest_time.h"
 #include "nest_types.h"
 #include "node.h"
@@ -383,8 +383,8 @@ private:
   /**
    * Register for gids of neurons that spiked. This is a 4-dim
    * structure. While spikes are written to the buffer they are
-   * immediately sorted by the thread the will move the to the MPI
-   * buffers.
+   * immediately sorted by the thread that will later move the spikes to the
+   * MPI buffers.
    * - First dim: write threads (from node to register)
    * - Second dim: read threads (from register to MPI buffer)
    * - Third dim: lag
@@ -396,8 +396,8 @@ private:
   /**
    * Register for gids of precise neurons that spiked. This is a 4-dim
    * structure. While spikes are written to the buffer they are
-   * immediately sorted by the thread the will move the to the MPI
-   * buffers.
+   * immediately sorted by the thread that will later move the spikes to the
+   * MPI buffers.
    * - First dim: write threads (from node to register)
    * - Second dim: read threads (from register to MPI buffer)
    * - Third dim: lag
@@ -412,12 +412,6 @@ private:
    */
   std::vector< unsigned int > send_buffer_secondary_events_;
   std::vector< unsigned int > recv_buffer_secondary_events_;
-
-  /**
-   * Marker Value to be put between the data fields from different time
-   * steps during communication.
-   */
-  const unsigned int comm_marker_;
 
   /**
    * Time that was spent on collocation of MPI buffers during the last call to
@@ -444,13 +438,10 @@ private:
 
   std::vector< TargetData > send_buffer_target_data_;
   std::vector< TargetData > recv_buffer_target_data_;
-
-  bool buffer_size_target_data_has_changed_; //!< whether size of MPI buffer for
-  // communication of connections was
-  // changed
-  bool buffer_size_spike_data_has_changed_; //!< whether size of MPI buffer for
-  // communication of spikes was
-  // changed
+  //!< whether size of MPI buffer for communication of connections was changed
+  bool buffer_size_target_data_has_changed_;
+  //!< whether size of MPI buffer for communication of spikes was changed
+  bool buffer_size_spike_data_has_changed_;
 
   CompletedChecker gather_completed_checker_;
 };

--- a/nestkernel/event_delivery_manager_impl.h
+++ b/nestkernel/event_delivery_manager_impl.h
@@ -26,8 +26,8 @@
 #include "event_delivery_manager.h"
 
 // Includes from nestkernel:
-#include "kernel_manager.h"
 #include "connection_manager_impl.h"
+#include "kernel_manager.h"
 
 namespace nest
 {


### PR DESCRIPTION
This is a PR to fix nest#717, to fix initialization and reset in `EventDeliveryManager`. When going though `EventDeliveryManager` I found that

- `comm_marker` is not used anywhere, so I have removed it
- there were some variables not initialized in the constructor, so I have added them
- there were some variables not cleared in `initialize()` or `finalize()`, so I added them
- I have also alphabetized some includes, and updated some comments.

Not all the variables are cleared in both `initialize()` and `finalize()`, so let me know if they should be cleared both places. So for instance `send_buffer_secondary_events_` is only cleared in `finalize()`. The variables previously not cleared in `finalize()` are reset through calls through `SimulationManager::prepare()` and `SimulationManager::SetStatus()`, but I figured it does not hurt to clear them in `finalize()` as well.