### PR TITLE
remove vector-of-pointer-to-vector-of-pointer-to-vector in SourceTables

### DIFF
--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -1478,7 +1478,7 @@ nest::ConnectionManager::sort_connections( const thread tid )
       {
         ( *( *connections_[ tid ] )[ syn_id ] )
           .sort_connections(
-            *source_table_.get_thread_local_sources( tid )[ syn_id ] );
+            source_table_.get_thread_local_sources( tid )[ syn_id ] );
       }
     }
     remove_disabled_connections( tid );

--- a/nestkernel/source_table.cpp
+++ b/nestkernel/source_table.cpp
@@ -53,8 +53,8 @@ nest::SourceTable::initialize()
 #pragma omp parallel
   {
     const thread tid = kernel().vp_manager.get_thread_id();
-    sources_[ tid ] = new std::vector< std::vector< Source >* >(
-      kernel().model_manager.get_num_synapse_prototypes(), NULL );
+    sources_[ tid ].resize(0); // =new std::vector< std::vector< Source > >(
+    //  kernel().model_manager.get_num_synapse_prototypes(), NULL );
     resize_sources( tid );
     current_positions_[ tid ] = new SourceTablePosition();
     saved_positions_[ tid ] = new SourceTablePosition();
@@ -73,13 +73,6 @@ nest::SourceTable::finalize()
     {
       clear( tid );
     }
-  }
-  for ( std::vector< std::vector< std::vector< Source >* >* >::iterator it =
-          sources_.begin();
-        it != sources_.end();
-        ++it )
-  {
-    delete *it;
   }
   sources_.clear();
   for ( std::vector< SourceTablePosition* >::iterator it =
@@ -112,10 +105,10 @@ nest::SourceTable::is_cleared() const
   return all_cleared;
 }
 
-std::vector< std::vector< nest::Source >* >&
+std::vector< std::vector< nest::Source > >&
 nest::SourceTable::get_thread_local_sources( const thread tid )
 {
-  return *sources_[ tid ];
+  return sources_[ tid ];
 }
 
 nest::SourceTablePosition
@@ -148,54 +141,37 @@ nest::SourceTable::clean( const thread tid )
   if ( max_position.tid == tid )
   {
     for ( synindex syn_id = max_position.syn_id;
-          syn_id < ( *sources_[ tid ] ).size();
+          syn_id < sources_[ tid ].size();
           ++syn_id )
     {
-      if ( ( *sources_[ tid ] )[ syn_id ] == NULL )
-      {
-        continue;
-      }
-      std::vector< Source >*& sources = ( *sources_[ tid ] )[ syn_id ];
+      std::vector< Source >& sources = sources_[ tid ][ syn_id ];
       if ( max_position.syn_id == syn_id )
       {
         // we need to add 2 to max_position.lcid since
         // max_position.lcid + 1 can contain a valid entry which we
         // do not want to delete.
-        if ( max_position.lcid + 2 < static_cast< long >( sources->size() ) )
+        if ( max_position.lcid + 2 < static_cast< long >( sources.size() ) )
         {
           const size_t deleted_elements =
-            sources->end() - ( sources->begin() + max_position.lcid + 2 );
-          sources->erase(
-            sources->begin() + max_position.lcid + 2, sources->end() );
+            sources.end() - ( sources.begin() + max_position.lcid + 2 );
+          sources.erase(
+            sources.begin() + max_position.lcid + 2, sources.end() );
           if ( deleted_elements > min_deleted_elements_ )
           {
-            std::vector< Source >( sources->begin(), sources->end() )
-              .swap( *sources );
+            std::vector< Source >( sources ).swap( sources );
           }
         }
       }
       else
       {
         assert( max_position.syn_id < syn_id );
-        sources->clear();
-        delete sources;
-        sources = NULL;
+        sources.clear();
       }
     }
   }
   else if ( max_position.tid < tid )
   {
-    for ( synindex syn_id = 0; syn_id < ( *sources_[ tid ] ).size(); ++syn_id )
-    {
-      if ( ( *sources_[ tid ] )[ syn_id ] == NULL )
-      {
-        continue;
-      }
-      std::vector< Source >*& sources = ( *sources_[ tid ] )[ syn_id ];
-      sources->clear();
-      delete sources;
-      sources = NULL;
-    }
+    sources_[ tid ].clear();
   }
   else
   {
@@ -209,8 +185,7 @@ nest::SourceTable::reserve( const thread tid,
   const synindex syn_id,
   const size_t count )
 {
-  ( *sources_[ tid ] )[ syn_id ]->reserve(
-    ( *sources_[ tid ] )[ syn_id ]->size() + count );
+  sources_[ tid ][ syn_id ].reserve( sources_[ tid ][ syn_id ].size() + count );
 }
 
 nest::index
@@ -223,19 +198,19 @@ nest::SourceTable::get_gid( const thread tid,
     throw KernelException(
       "Cannot use SourceTable::get_gid when get_keep_source_table is false" );
   }
-  return ( *( *sources_[ tid ] )[ syn_id ] )[ lcid ].get_gid();
+  return sources_[ tid ][ syn_id ][ lcid ].get_gid();
 }
 
 nest::index
 nest::SourceTable::remove_disabled_sources( const thread tid,
   const synindex syn_id )
 {
-  if ( ( *sources_[ tid ] )[ syn_id ] == NULL )
+  if ( sources_[ tid ].size() <= syn_id )
   {
     return invalid_index;
   }
 
-  std::vector< Source >& mysources = *( *sources_[ tid ] )[ syn_id ];
+  std::vector< Source >& mysources = sources_[ tid ][ syn_id ];
   const index max_size = mysources.size();
   if ( max_size == 0 )
   {
@@ -281,15 +256,15 @@ nest::SourceTable::compute_buffer_pos_for_unique_secondary_sources(
   // corresponding to continuous-data connections on this MPI rank;
   // using a set makes sure secondary events are not duplicated for
   // targets on the same process, but different threads
-  for ( size_t syn_id = 0; syn_id < sources_[ tid ]->size(); ++syn_id )
+  for ( size_t syn_id = 0; syn_id < sources_[ tid ].size(); ++syn_id )
   {
     if ( not kernel()
                .model_manager.get_synapse_prototype( syn_id, tid )
                .is_primary() )
     {
       for ( std::vector< Source >::const_iterator source_cit =
-              ( *sources_[ tid ] )[ syn_id ]->begin();
-            source_cit != ( *sources_[ tid ] )[ syn_id ]->end();
+              sources_[ tid ][ syn_id ].begin();
+            source_cit != sources_[ tid ][ syn_id ].end();
             ++source_cit )
       {
 #pragma omp critical
@@ -343,15 +318,7 @@ nest::SourceTable::compute_buffer_pos_for_unique_secondary_sources(
 void
 nest::SourceTable::resize_sources( const thread tid )
 {
-  sources_[ tid ]->resize(
-    kernel().model_manager.get_num_synapse_prototypes(), NULL );
-  for ( size_t syn_id = 0; syn_id < sources_[ tid ]->size(); ++syn_id )
-  {
-    if ( ( *sources_[ tid ] )[ syn_id ] == NULL )
-    {
-      ( *sources_[ tid ] )[ syn_id ] = new std::vector< Source >( 0 );
-    }
-  }
+  sources_[ tid ].resize( kernel().model_manager.get_num_synapse_prototypes() );
 }
 
 bool
@@ -376,8 +343,7 @@ nest::SourceTable::get_next_target_data( const thread tid,
 
     // the current position contains an entry, so we retrieve it
     const Source& const_current_source =
-      ( *( *sources_[ current_position.tid ] )[ current_position.syn_id ] )
-        [ current_position.lcid ];
+      sources_[ current_position.tid ][ current_position.syn_id ][ current_position.lcid ];
 
     if ( const_current_source.is_processed()
       or const_current_source.is_disabled() )
@@ -401,8 +367,7 @@ nest::SourceTable::get_next_target_data( const thread tid,
     }
 
     Source& current_source =
-      ( *( *sources_[ current_position.tid ] )[ current_position.syn_id ] )
-        [ current_position.lcid ];
+      sources_[ current_position.tid ][ current_position.syn_id ][ current_position.lcid ];
 
     // we have found a valid entry, so mark it as processed
     current_source.set_processed( true );
@@ -417,11 +382,8 @@ nest::SourceTable::get_next_target_data( const thread tid,
       false );
     if ( ( current_position.lcid + 1
              < static_cast< long >(
-                 ( *sources_[ current_position.tid ] )[ current_position
-                                                          .syn_id ]->size() )
-           and ( *( *sources_[ current_position.tid ] )
-                   [ current_position.syn_id ] )[ current_position.lcid + 1 ]
-                 .get_gid() == current_source.get_gid() ) )
+                 sources_[ current_position.tid ][ current_position.syn_id ].size() )
+           and sources_[ current_position.tid ][ current_position.syn_id ][ current_position.lcid + 1 ].get_gid() == current_source.get_gid() ) )
     {
       kernel().connection_manager.set_has_source_subsequent_targets(
         current_position.tid,
@@ -434,13 +396,9 @@ nest::SourceTable::get_next_target_data( const thread tid,
     // entry preceding this entry has the same source, but only if
     // the preceding entry was not processed yet
     if ( ( current_position.lcid - 1 >= 0 )
-      and ( ( *(
-                *sources_[ current_position.tid ] )[ current_position.syn_id ] )
-              [ current_position.lcid - 1 ].get_gid()
+      and ( sources_[ current_position.tid ][ current_position.syn_id ][ current_position.lcid - 1 ].get_gid()
             == current_source.get_gid() )
-      and ( not( *( *sources_[ current_position.tid ] )
-                   [ current_position.syn_id ] )[ current_position.lcid - 1 ]
-                 .is_processed() ) )
+      and ( not sources_[ current_position.tid ][ current_position.syn_id ][ current_position.lcid - 1 ].is_processed() ) )
     {
       --current_position.lcid;
       continue;

--- a/nestkernel/source_table.cpp
+++ b/nestkernel/source_table.cpp
@@ -53,8 +53,6 @@ nest::SourceTable::initialize()
 #pragma omp parallel
   {
     const thread tid = kernel().vp_manager.get_thread_id();
-    sources_[ tid ].resize(0); // =new std::vector< std::vector< Source > >(
-    //  kernel().model_manager.get_num_synapse_prototypes(), NULL );
     resize_sources( tid );
     is_cleared_[ tid ] = false;
     saved_entry_point_[ tid ] = false;

--- a/nestkernel/source_table.h
+++ b/nestkernel/source_table.h
@@ -64,7 +64,7 @@ private:
   /**
    * 3D structure storing gids of presynaptic neurons.
    */
-  std::vector< std::vector< std::vector< Source >* >* > sources_;
+  std::vector< std::vector< std::vector< Source > > > sources_;
 
   /**
    * Whether the 3D structure has been deleted.
@@ -171,7 +171,7 @@ public:
    * Returns a reference to all sources local on thread; necessary
    * for sorting.
    */
-  std::vector< std::vector< Source >* >& get_thread_local_sources(
+  std::vector< std::vector< Source > >& get_thread_local_sources(
     const thread tid );
 
   /**
@@ -264,26 +264,22 @@ SourceTable::add_source( const thread tid,
 {
   const Source src( gid, is_primary );
 
-  vector_util::grow( ( *( *sources_[ tid ] )[ syn_id ] ) );
+  vector_util::grow( sources_[ tid ][ syn_id ] );
 
-  ( *sources_[ tid ] )[ syn_id ]->push_back( src );
+  sources_[ tid ][ syn_id ].push_back( src );
 }
 
 inline void
 SourceTable::clear( const thread tid )
 {
-  for ( std::vector< std::vector< Source >* >::iterator it =
-          sources_[ tid ]->begin();
-        it != sources_[ tid ]->end();
+  for ( std::vector< std::vector< Source > >::iterator it =
+          sources_[ tid ].begin();
+        it != sources_[ tid ].end();
         ++it )
   {
-    if ( ( *it ) != NULL )
-    {
-      ( *it )->clear();
-      delete *it;
-    }
+      it->clear();
   }
-  sources_[ tid ]->clear();
+  sources_[ tid ].clear();
   is_cleared_[ tid ] = true;
 }
 
@@ -296,13 +292,9 @@ SourceTable::reject_last_target_data( const thread tid )
   // source_table_impl.h)
   assert( ( *current_positions_[ tid ] ).lcid + 1
     < static_cast< long >(
-            ( *sources_[ ( *current_positions_[ tid ] )
-                           .tid ] )[ ( *current_positions_[ tid ] ).syn_id ]
-              ->size() ) );
+             sources_[ ( *current_positions_[ tid ] ).tid ][ ( *current_positions_[ tid ] ).syn_id ].size() ) );
 
-  ( *( *sources_[ ( *current_positions_[ tid ] )
-                    .tid ] )[ ( *current_positions_[ tid ] )
-                                .syn_id ] )[ ( *current_positions_[ tid ] ).lcid
+  sources_[ ( *current_positions_[ tid ] ).tid ][ ( *current_positions_[ tid ] ).syn_id ][ ( *current_positions_[ tid ] ).lcid
     + 1 ].set_processed( false );
 }
 
@@ -324,9 +316,7 @@ SourceTable::save_entry_point( const thread tid )
       ( *saved_positions_[ tid ] ).lcid = std::min(
         ( *current_positions_[ tid ] ).lcid + 1,
         static_cast< long >(
-          ( *sources_[ ( *current_positions_[ tid ] )
-                         .tid ] )[ ( *current_positions_[ tid ] ).syn_id ]
-            ->size() - 1 ) );
+          sources_[ ( *current_positions_[ tid ] ).tid ][ ( *current_positions_[ tid ] ).syn_id ].size() - 1 ) );
     }
     else
     {
@@ -356,7 +346,7 @@ SourceTable::reset_entry_point( const thread tid )
   if ( ( *saved_positions_[ tid ] ).tid > -1 )
   {
     ( *saved_positions_[ tid ] ).syn_id =
-      ( *sources_[ ( *saved_positions_[ tid ] ).tid ] ).size() - 1;
+      sources_[ ( *saved_positions_[ tid ] ).tid ].size() - 1;
   }
   else
   {
@@ -365,9 +355,7 @@ SourceTable::reset_entry_point( const thread tid )
   if ( ( *saved_positions_[ tid ] ).syn_id > -1 )
   {
     ( *saved_positions_[ tid ] ).lcid =
-      ( *sources_[ ( *saved_positions_[ tid ] )
-                     .tid ] )[ ( *saved_positions_[ tid ] ).syn_id ]->size()
-      - 1;
+      sources_[ ( *saved_positions_[ tid ] ).tid ][ ( *saved_positions_[ tid ] ).syn_id ].size() - 1;
   }
   else
   {
@@ -378,13 +366,13 @@ SourceTable::reset_entry_point( const thread tid )
 inline void
 SourceTable::reset_processed_flags( const thread tid )
 {
-  for ( std::vector< std::vector< Source >* >::iterator it =
-          ( *sources_[ tid ] ).begin();
-        it != ( *sources_[ tid ] ).end();
+  for ( std::vector< std::vector< Source > >::iterator it =
+          sources_[ tid ].begin();
+        it != sources_[ tid ].end();
         ++it )
   {
-    for ( std::vector< Source >::iterator iit = ( *it )->begin();
-          iit != ( *it )->end();
+    for ( std::vector< Source >::iterator iit = it->begin();
+          iit != it->end();
           ++iit )
     {
       iit->set_processed( false );
@@ -407,9 +395,9 @@ SourceTable::find_first_source( const thread tid,
 {
   // binary search in sorted sources
   const std::vector< Source >::const_iterator begin =
-    ( *( *sources_[ tid ] )[ syn_id ] ).begin();
+    sources_[ tid ][ syn_id ].begin();
   const std::vector< Source >::const_iterator end =
-    ( *( *sources_[ tid ] )[ syn_id ] ).end();
+    sources_[ tid ][ syn_id ].end();
   std::vector< Source >::const_iterator it =
     std::lower_bound( begin, end, Source( sgid, true ) );
 
@@ -436,8 +424,8 @@ SourceTable::disable_connection( const thread tid,
 {
   // disabling a source changes its gid to 2^62 -1
   // source here
-  assert( not( *( *sources_[ tid ] )[ syn_id ] )[ lcid ].is_disabled() );
-  ( *( *sources_[ tid ] )[ syn_id ] )[ lcid ].disable();
+  assert( not sources_[ tid ][ syn_id ][ lcid ].is_disabled() );
+  sources_[ tid ][ syn_id ][ lcid ].disable();
 }
 
 inline void
@@ -450,7 +438,7 @@ SourceTable::get_source_gids( const thread tid,
         cit != source_lcids.end();
         ++cit )
   {
-    sources.push_back( ( *( *sources_[ tid ] )[ syn_id ] )[ *cit ].get_gid() );
+    sources.push_back( sources_[ tid ][ syn_id ][ *cit ].get_gid() );
   }
 }
 
@@ -460,8 +448,8 @@ SourceTable::num_unique_sources( const thread tid, const synindex syn_id ) const
   size_t n = 0;
   index last_source = 0;
   for ( std::vector< Source >::const_iterator cit =
-          ( *( *sources_[ tid ] )[ syn_id ] ).begin();
-        cit != ( *( *sources_[ tid ] )[ syn_id ] ).end();
+          sources_[ tid ][ syn_id ].begin();
+        cit != sources_[ tid ][ syn_id ].end();
         ++cit )
   {
     if ( last_source != ( *cit ).get_gid() )

--- a/nestkernel/source_table_position.h
+++ b/nestkernel/source_table_position.h
@@ -45,7 +45,7 @@ struct SourceTablePosition
 
   template < typename T >
   void wrap_position(
-    const std::vector< std::vector< std::vector< T >* >* >& sources );
+    const std::vector< std::vector< std::vector< T > > >& sources );
 
   bool is_at_end() const;
 };
@@ -77,7 +77,7 @@ inline SourceTablePosition::SourceTablePosition(
 template < typename T >
 inline void
 SourceTablePosition::wrap_position(
-  const std::vector< std::vector< std::vector< T >* >* >& sources )
+  const std::vector< std::vector< std::vector< T > > >& sources )
 {
   // check for validity of indices and update if necessary
   while ( lcid < 0 )
@@ -85,17 +85,17 @@ SourceTablePosition::wrap_position(
     --syn_id;
     if ( syn_id >= 0 )
     {
-      lcid = ( *sources[ tid ] )[ syn_id ]->size() - 1;
+      lcid = sources[ tid ][ syn_id ].size() - 1;
       continue;
     }
 
     --tid;
     if ( tid >= 0 )
     {
-      syn_id = ( *sources[ tid ] ).size() - 1;
+      syn_id = sources[ tid ].size() - 1;
       if ( syn_id >= 0 )
       {
-        lcid = ( *sources[ tid ] )[ syn_id ]->size() - 1;
+        lcid = sources[ tid ][ syn_id ].size() - 1;
       }
       continue;
     }


### PR DESCRIPTION
This PR simplifies many constructs in `SourceTable` by using vectors with actual objects instead of pointers.